### PR TITLE
[Overlap Blocker] Added "of" to list of stop_words

### DIFF
--- a/py_entitymatching/blocker/overlap_blocker.py
+++ b/py_entitymatching/blocker/overlap_blocker.py
@@ -30,7 +30,7 @@ class OverlapBlocker(Blocker):
                            'be', 'by', 'for', 'from',
                            'has', 'he', 'in', 'is', 'it',
                            'its', 'on', 'that', 'the', 'to',
-                           'was', 'were', 'will', 'with']
+                           'was', 'were', 'will', 'with', 'of']
         self.regex_punctuation = re.compile(
             '[%s]' % re.escape(string.punctuation))
         super(OverlapBlocker, self).__init__()


### PR DESCRIPTION
This quick change resolves #44. Our team solved the issue in our local version to help reduce false pairs from blocking. Just thought I would share our fix, but feel free to ignore/reject this.