### PR TITLE
[OverlapBlocker] Fixes rem_stop_words attribute in block_candset() to run stop word pruning conditionally

### DIFF
--- a/py_entitymatching/blocker/overlap_blocker.py
+++ b/py_entitymatching/blocker/overlap_blocker.py
@@ -581,8 +581,11 @@ class OverlapBlocker(Blocker):
                 # chop the attribute values and convert into a set
                 val_chopped = list(set(val_no_punctuations.split()))
                 # remove stop words
-                val_chopped_no_stopwords = self.rem_stopwords(val_chopped)
-                val_joined = ' '.join(val_chopped_no_stopwords)
+                if rem_stop_words:
+                    val_chopped_no_stopwords = self.rem_stopwords(val_chopped)
+                    val_joined = ' '.join(val_chopped_no_stopwords)
+                else:
+                    val_joined = ' '.join(val_chopped)
                 values.append(val_joined)
 
         table.is_copy = False
@@ -599,8 +602,11 @@ class OverlapBlocker(Blocker):
         # chop the attribute values and convert into a set
         val_chopped = list(set(val_no_punctuations.split()))
         # remove stop words
-        val_chopped_no_stopwords = self.rem_stopwords(val_chopped)
-        val_joined = ' '.join(val_chopped_no_stopwords)
+        if rem_stop_words:
+            val_chopped_no_stopwords = self.rem_stopwords(val_chopped)
+            val_joined = ' '.join(val_chopped_no_stopwords)
+        else:
+            val_joined = ' '.join(val_chopped)
         return val_joined
 
     def rem_punctuations(self, s):


### PR DESCRIPTION
Proposed solution which fixes #46. Some testing on my machine shows that block_candset() now uses the rem_stop_words attribute as promised, but more testing recommended. Feel free to kill this pull request and fix as needed, just thought I would share solution our group came up with and used, if only to highlight main source of problem.

