### PR TITLE
Fix bug in abs_norm with negative number

### DIFF
--- a/py_entitymatching/feature/simfunctions.py
+++ b/py_entitymatching/feature/simfunctions.py
@@ -760,7 +760,7 @@ def abs_norm(d1, d2):
         return 0
     else:
         # Compute absolute norm similarity between two numbers.
-        x = (abs(d1 - d2) / max(d1, d2))
+        x = (abs(d1 - d2) / max(abs(d1), abs(d2)))
         if x <= 10e-5:
             x = 0
         return 1.0 - x


### PR DESCRIPTION
em.abs_norm(0.0, -1.0) will throw ZeroDivisionError in previous version.