### PR TITLE
Test the installation process alongside unit tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,56 +2,97 @@ matrix:
   include:
   - os: linux
     python: 2.7
-    env: PYTHON_VERSION=2.7
+    env:
+      - PYTHON_VERSION=2.7
+      - INSTALL_METHOD=src
+  - os: linux
+    python: 2.7
+    env:
+      - PYTHON_VERSION=2.7
+      - INSTALL_METHOD=pip
   - os: linux
     python: 3.5
-    env: PYTHON_VERSION=3.5
+    env:
+      - PYTHON_VERSION=3.5
+      - INSTALL_METHOD=src
   - os: linux
-    python: 3.6
-    env: PYTHON_VERSION=3.6
+    python: 3.5
+    env:
+      - PYTHON_VERSION=3.5
+      - INSTALL_METHOD=pip
+  - os: linux                                                                   
+    python: 3.6                                                                 
+    env:
+      - PYTHON_VERSION=3.6
+      - INSTALL_METHOD=src
+  - os: linux                                                                   
+    python: 3.6                                                                 
+    env:
+      - PYTHON_VERSION=3.6
+      - INSTALL_METHOD=pip
   - os: linux
     python: 3.7
-    env: PYTHON_VERSION=3.7
+    env:
+      - PYTHON_VERSION=3.7
+      - INSTALL_METHOD=src
+  - os: linux
+    python: 3.7
+    env:
+      - PYTHON_VERSION=3.7
+      - INSTALL_METHOD=pip
   - os: osx
     language: generic
     env:
-    - PYTHON_VERSION=2.7
+      - PYTHON_VERSION=2.7
+      - INSTALL_METHOD=src
   - os: osx
     language: generic
     env:
-    - PYTHON_VERSION=3.5
+      - PYTHON_VERSION=2.7
+      - INSTALL_METHOD=pip
   - os: osx
     language: generic
     env:
-    - PYTHON_VERSION=3.6
+      - PYTHON_VERSION=3.5
+      - INSTALL_METHOD=src
   - os: osx
     language: generic
     env:
-    - PYTHON_VERSION=3.7
+      - PYTHON_VERSION=3.5
+      - INSTALL_METHOD=pip
+  - os: osx                                                                     
+    language: generic                                                           
+    env:                                                                        
+      - PYTHON_VERSION=3.6
+      - INSTALL_METHOD=src
+  - os: osx                                                                     
+    language: generic                                                           
+    env:                                                                        
+      - PYTHON_VERSION=3.6
+      - INSTALL_METHOD=pip
+  - os: osx
+    language: generic
+    env:
+      - PYTHON_VERSION=3.7
+      - INSTALL_METHOD=src
+  - os: osx
+    language: generic
+    env:
+      - PYTHON_VERSION=3.7
+      - INSTALL_METHOD=pip
 
+compiler:
+    - gcc
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$PYTHON_VERSION" == 2.* ]]; then wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$PYTHON_VERSION" == 3.* ]]; then wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$PYTHON_VERSION" == 2.* ]]; then wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$PYTHON_VERSION" == 3.* ]]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
+  - if [ "$TRAVIS_OS_NAME" == linux ]; then MINICONDAVERSION="Linux"; else MINICONDAVERSION="MacOSX"; fi
+  - if [ "$PYTHON_VERSION" == "2.7" ]; then wget http://repo.continuum.io/miniconda/Miniconda2-latest-$MINICONDAVERSION-x86_64.sh -O miniconda.sh; fi
+  - if [ "$PYTHON_VERSION" != "2.7" ]; then wget http://repo.continuum.io/miniconda/Miniconda3-latest-$MINICONDAVERSION-x86_64.sh -O miniconda.sh; fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
-#  - conda update --yes conda
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
-  - conda config --add channels conda-forge
-  - echo $PYTHON_VERSION
-  - conda create -n testenv python=$PYTHON_VERSION  --yes
-  - source activate testenv
-  - if [[ "$PYTHON_VERSION" == 3.5 ]]; then pip install PyQt5; fi
-  - if [[ "$PYTHON_VERSION" == 3.6 ]]; then pip install PyQt5; fi
+  - conda create --yes -n py_entitymatching_test_env python=$PYTHON_VERSION --no-default-packages
+  - python --version  
 
-install:
-  - conda install --yes python=$PYTHON_VERSION nose
-  - pip install requests
-  - pip install -r requirements.txt
-  - python setup.py build_ext --inplace
-  
-script:  
-  - nosetests -s
+install: TRAVIS_OS_NAME="$TRAVIS_OS_NAME" ./ci-scripts/install-${INSTALL_METHOD}.sh
+
+script: ./ci-scripts/test-from-${INSTALL_METHOD}.sh

--- a/ci-scripts/install-pip.sh
+++ b/ci-scripts/install-pip.sh
@@ -2,6 +2,8 @@
 
 # Install this package and its dependencies using pip.
 
+set -e
+
 source activate py_entitymatching_test_env
 
 # Package dependencies (TODO: factor this out)

--- a/ci-scripts/install-pip.sh
+++ b/ci-scripts/install-pip.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Install this package and its dependencies using pip.
+
+source activate py_entitymatching_test_env
+
+# Package dependencies (TODO: factor this out)
+pip install -r requirements.txt
+
+# Install from TestPyPI
+pip install -i https://test.pypi.org/simple/ py-entitymatching

--- a/ci-scripts/install-src.sh
+++ b/ci-scripts/install-src.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Install this package and its dependencies from source.
+
+source activate py_entitymatching_test_env
+
+# System dependencies
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then conda install --yes gcc; fi
+which gcc
+
+# Package dependencies
+pip install -r requirements.txt
+
+# Build dependencies
+pip install Cython
+
+# Install package
+python setup.py install

--- a/ci-scripts/install-src.sh
+++ b/ci-scripts/install-src.sh
@@ -2,6 +2,8 @@
 
 # Install this package and its dependencies from source.
 
+set -e
+
 source activate py_entitymatching_test_env
 
 # System dependencies

--- a/ci-scripts/test-from-pip.sh
+++ b/ci-scripts/test-from-pip.sh
@@ -2,6 +2,8 @@
 
 # Test the package from pip install.
 
+set -e
+
 source activate py_entitymatching_test_env
 
 # Test install (no unit tests here)

--- a/ci-scripts/test-from-pip.sh
+++ b/ci-scripts/test-from-pip.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Test the package from pip install.
+
+source activate py_entitymatching_test_env
+
+# Test install (no unit tests here)
+cd ~
+pwd
+python -c "import py_entitymatching; print(py_entitymatching.__version__)"

--- a/ci-scripts/test-from-src.sh
+++ b/ci-scripts/test-from-src.sh
@@ -2,6 +2,8 @@
 
 # Test the package from source install.
 
+set -e
+
 source activate py_entitymatching_test_env
 
 # Unit tests

--- a/ci-scripts/test-from-src.sh
+++ b/ci-scripts/test-from-src.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Test the package from source install.
+
+source activate py_entitymatching_test_env
+
+# Unit tests
+pip install nosetests
+python setup.py build_ext --inplace
+nosetests -s
+
+# Test install
+cd ~
+pwd
+python -c "import py_entitymatching; print(py_entitymatching.__version__)"

--- a/ci-scripts/test-from-src.sh
+++ b/ci-scripts/test-from-src.sh
@@ -7,7 +7,7 @@ set -e
 source activate py_entitymatching_test_env
 
 # Unit tests
-pip install nosetests
+pip install nose
 python setup.py build_ext --inplace
 nosetests -s
 


### PR DESCRIPTION
Previously, Travis CI didn't test that a package could be installed successfully in a user's environment; it only ran unit tests from project root. These updates add package installation tests, embedding unit tests in the script `ci-scripts/test-from-src.sh`.