### PR TITLE
Fixed abs_norm sim measure for negative numbers

### DIFF
--- a/py_entitymatching/feature/simfunctions.py
+++ b/py_entitymatching/feature/simfunctions.py
@@ -760,7 +760,7 @@ def abs_norm(d1, d2):
         return 0
     else:
         # Compute absolute norm similarity between two numbers.
-        x = (abs(d1 - d2) / max(d1, d2))
+        x = (abs(d1 - d2) / max(abs(d1), abs(d2)))
         if x <= 10e-5:
             x = 0
         return 1.0 - x


### PR DESCRIPTION
Fixed bug involving using the absolute norm measure for negative values. Previously, if either input was negative and the other was zero, it would cause a divide by zero error. Now, the absolute values are used to prevent this situation as well as keeping the similarity score between 0 and 1.