### PR TITLE
Let users define sensible feature table attrs for blackbox features.

### DIFF
--- a/py_entitymatching/feature/addfeatures.py
+++ b/py_entitymatching/feature/addfeatures.py
@@ -327,7 +327,7 @@ def create_feature_table():
     return feature_table
 
 
-def add_blackbox_feature(feature_table, feature_name, feature_function):
+def add_blackbox_feature(feature_table, feature_name, feature_function, **kwargs):
     """
     Adds a black box feature to the feature table.
 
@@ -389,12 +389,12 @@ def add_blackbox_feature(feature_table, feature_name, feature_function):
     feature_dict = {}
     feature_dict['feature_name'] = feature_name
     feature_dict['function'] = feature_function
-    feature_dict['left_attribute'] = None
-    feature_dict['right_attribute'] = None
-    feature_dict['left_attr_tokenizer'] = None
-    feature_dict['right_attr_tokenizer'] = None
-    feature_dict['simfunction'] = None
-    feature_dict['function_source'] = None
+    feature_dict['left_attribute'] = kwargs.get('left_attribute')
+    feature_dict['right_attribute'] = kwargs.get('right_attribute')
+    feature_dict['left_attr_tokenizer'] = kwargs.get('left_attr_tokenizer')
+    feature_dict['right_attr_tokenizer'] = kwargs.get('right_attr_tokenizer')
+    feature_dict['simfunction'] = kwargs.get('simfunction')
+    feature_dict['function_source'] = kwargs.get('function_source')
     feature_dict['is_auto_generated'] = False
 
     # Add the feature to the feature table as a last entry.

--- a/py_entitymatching/tests/test_feature_addfeatures.py
+++ b/py_entitymatching/tests/test_feature_addfeatures.py
@@ -193,6 +193,26 @@ class AddBlackBoxFeatureTestCases(unittest.TestCase):
         len2 = len(feature_table)
         self.assertEqual(len1+1, len2)
         self.assertEqual(feature_table.loc[len(feature_table)-1, 'function'](A.loc[1], B.loc[2]), 1.0)
+    
+    def test_add_bb_feature_with_attrs(self):
+        A = read_csv_metadata(path_a)
+        B = read_csv_metadata(path_b, key='ID')
+        feature_table = get_features_for_matching(A, B, validate_inferred_attr_types=False)
+        def bb_fn(ltuple, rtuple):
+            return min(len(ltuple['name']), len(rtuple['name']))
+        len1 = len(feature_table)
+        attrs = {
+            'left_attribute': 'name',
+            'right_attribute': 'name'
+        }
+        add_blackbox_feature(feature_table, 'bb_attr_test', bb_fn, **attrs)
+        len2 = len(feature_table)
+        self.assertEqual(len1+1, len2)
+        added_feature = feature_table.iloc[len(feature_table)-1]
+        self.assertEqual(added_feature.feature_name, 'bb_attr_test')
+        self.assertEqual(added_feature.left_attribute, 'name')
+        self.assertEqual(added_feature.right_attribute, 'name')
+        self.assertEqual(added_feature.simfunction, None)
 
     @raises(AssertionError)
     def test_add_bb_feature_invalid_df(self):


### PR DESCRIPTION
For environments that makes use of both auto-generated and blackbox features, feature generation can take up to a day on tables with millions of records and tens of features. To optimize the feature generation process, it would be useful to have non-null feature metadata for blackbox features in addition to the metadata that is already implemented for built-in features. This PR is intended as a first step towards optimizing feature generation by allowing developers to manually provide sensible attributes for blackbox features in the feature table.