### PR TITLE
Fix macos from source

### DIFF
--- a/ci-scripts/install-pip.sh
+++ b/ci-scripts/install-pip.sh
@@ -6,6 +6,10 @@ set -e
 
 source activate py_entitymatching_test_env
 
+# Packages required at dependency build time (patch)
+pip install numpy==1.16.2
+pip install scikit-learn==0.20
+
 # Package dependencies (TODO: factor this out)
 pip install -r requirements.txt
 

--- a/ci-scripts/install-src.sh
+++ b/ci-scripts/install-src.sh
@@ -7,7 +7,6 @@ set -e
 source activate py_entitymatching_test_env
 
 # System dependencies
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then conda install --yes gcc; fi
 which gcc
 
 # Package dependencies

--- a/ci-scripts/install-src.sh
+++ b/ci-scripts/install-src.sh
@@ -9,6 +9,10 @@ source activate py_entitymatching_test_env
 # System dependencies
 which gcc
 
+# Packages required at dependency build time (patch)
+pip install numpy==1.16.2
+pip install scikit-learn==0.20
+
 # Package dependencies
 pip install -r requirements.txt
 


### PR DESCRIPTION
The build on macOS from source has been broken for a while now. It's because recent versions of conda have dropped gcc as an available package (there are other related packages):

```bash
# Known version of conda with gcc available
docker container run --name conda4.4 continuumio/miniconda:4.4.10 conda search gcc

# Latest version of conda
docker container run --name condalatest continuumio/miniconda:latest conda search gcc
```

This PR simply drops the conditional installation of gcc on macOS; the latest macOS instances on Travis have gcc installed.

NOTE: As a temporary solution, this PR also contains pinned numpy and scikit-learn versions prior to installing dependencies. This is currently necessary in order to support Python 2.7 and to avoid #127. A long-term solution should fix #127 and drop support for Python 2.