### PR TITLE
Fix imputer

### DIFF
--- a/docs/user_manual/imputing_missing_values.rst
+++ b/docs/user_manual/imputing_missing_values.rst
@@ -21,7 +21,7 @@ or fill the NaN's with an aggregate value (mean, median, etc.).
 
 Since the table is represented as a pandas Dataframe, there are two common ways to impute
 missing values: (1) use `fillna` method from pandas Dataframe, and (2) impute missing
-values using `Imputer` from Scikit-learn package.
+values using `SimpleImputer` from Scikit-learn package.
 
 But there are two problems that we have to tackle if we have to using the above commands
 or objects directly:
@@ -54,7 +54,7 @@ the output is getting assigned to a column in the old Dataframe `H` and the meta
 of `H` does not get affected.
 
 To fill NaN's with an aggregate value, in py_entitymatching you can use `impute_table`
-command. It is a wrapper around scikit-learn's `Imputer` object (to make it metadata aware).
+command. It is a wrapper around scikit-learn's `SimpleImputer` object (to make it metadata aware).
 An example of using `impute_table` is shown below:
 
     >>> H = em.impute_table(H, exclude_attrs=['_id', 'ltable_id', 'rtable_id'], strategy='mean')

--- a/py_entitymatching/matcher/matcherutils.py
+++ b/py_entitymatching/matcher/matcherutils.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 
 import pandas as pd
 import sklearn.model_selection as ms
-from  sklearn.preprocessing import Imputer
+from  sklearn.impute import SimpleImputer
 
 import py_entitymatching.catalog.catalog_manager as cm
 import py_entitymatching.utils.catalog_helper as ch
@@ -131,7 +131,7 @@ def get_ts():
 
 
 def impute_table(table, exclude_attrs=None, missing_val='NaN',
-                 strategy='mean', axis=0, val_all_nans=0, verbose=True):
+                 strategy='mean', fill_value=None, val_all_nans=0, verbose=True):
     """
     Impute table containing missing values.
 
@@ -145,8 +145,8 @@ def impute_table(table, exclude_attrs=None, missing_val='NaN',
             (defaults to 'NaN').
         strategy (string): String that specifies on how to impute values. Valid
             strings: 'mean', 'median', 'most_frequent' (defaults to 'mean').
-        axis (int):  axis=1 along rows, and axis=0 along columns  (defaults
-            to 0).
+        fill_value (any):  When strategy == "constant", `fill_value` is used to replace
+            all occurrences of missing values.
         val_all_nans (float): Value to fill in if all the values in the column
             are NaN.
 
@@ -218,7 +218,7 @@ def impute_table(table, exclude_attrs=None, missing_val='NaN',
 
     projected_table_values = projected_table.values
 
-    imp = Imputer(missing_values=missing_val, strategy=strategy, axis=axis)
+    imp = SimpleImputer(missing_values=missing_val, strategy=strategy, fill_value=fill_value)
     imp.fit(projected_table_values)
     imp.statistics_[pd.np.isnan(imp.statistics_)] = val_all_nans
     projected_table_values = imp.transform(projected_table_values)


### PR DESCRIPTION
[sklearn.preprocessing.Imputer](https://scikit-learn.org/0.16/modules/generated/sklearn.preprocessing.Imputer.html) was deprecated and is now no longer available in the most recent versions of scikit-learn. This PR replaces it with its new equivalent [sklearn.impute.SimpleImputer](https://scikit-learn.org/stable/modules/generated/sklearn.impute.SimpleImputer.html). Updating to `SimpleImputer` is required for supporting Python 3.8 in the future; see #127.