### PR TITLE
Update DataFrame indexers

### DIFF
--- a/py_entitymatching/blocker/attr_equiv_blocker.py
+++ b/py_entitymatching/blocker/attr_equiv_blocker.py
@@ -392,7 +392,7 @@ class AttrEquivalenceBlocker(Blocker):
             >>> A = em.read_csv_metadata('path_to_csv_dir/table_A.csv', key='ID')
             >>> B = em.read_csv_metadata('path_to_csv_dir/table_B.csv', key='ID')
             >>> ab = em.AttrEquivalenceBlocker()
-            >>> status = ab.block_tuples(A.ix[0], B.ix[0], 'zipcode', 'zipcode')
+            >>> status = ab.block_tuples(A.loc[0], B.loc[0], 'zipcode', 'zipcode')
         """
         l_val, r_val = ltuple[l_block_attr], rtuple[r_block_attr]
         if allow_missing:
@@ -511,12 +511,12 @@ def _block_candset_split(c_df, l_df, r_df, l_key, r_key,
         # # get the value of block attributes
         row_lkey = row[lkey_idx]
         if row_lkey not in l_dict:
-            l_dict[row_lkey] = l_df.ix[row_lkey, l_block_attr]
+            l_dict[row_lkey] = l_df.loc[row_lkey, l_block_attr]
         l_val = l_dict[row_lkey]
 
         row_rkey = row[rkey_idx]
         if row_rkey not in r_dict:
-            r_dict[row_rkey] = r_df.ix[row_rkey, r_block_attr]
+            r_dict[row_rkey] = r_df.loc[row_rkey, r_block_attr]
         r_val = r_dict[row_rkey]
 
         if allow_missing:

--- a/py_entitymatching/blocker/black_box_blocker.py
+++ b/py_entitymatching/blocker/black_box_blocker.py
@@ -370,7 +370,7 @@ class BlackBoxBlocker(Blocker):
             >>> import py_entitymatching as em
             >>> bb = em.BlackBoxBlocker()
             >>> bb.set_black_box_function(match_last_name)
-            >>> status = bb.block_tuples(A.ix[0], B.ix[0]) # A, B are input tables.
+            >>> status = bb.block_tuples(A.loc[0], B.loc[0]) # A, B are input tables.
 
         """
 
@@ -482,13 +482,13 @@ def _block_candset_split(c_df, l_df, r_df, l_key, r_key, fk_ltable, fk_rtable,
         # # get ltuple, try dictionary first, then dataframe
         row_lkey = row[l_id_pos]
         if row_lkey not in l_dict:
-            l_dict[row_lkey] = l_df.ix[row_lkey]
+            l_dict[row_lkey] = l_df.loc[row_lkey]
         ltuple = l_dict[row_lkey]
 
         # # get rtuple, try dictionary first, then dataframe
         row_rkey = row[r_id_pos]
         if row_rkey not in r_dict:
-            r_dict[row_rkey] = r_df.ix[row_rkey]
+            r_dict[row_rkey] = r_df.loc[row_rkey]
         rtuple = r_dict[row_rkey]
 
         # # apply the black box function to the tuple pair

--- a/py_entitymatching/blocker/overlap_blocker.py
+++ b/py_entitymatching/blocker/overlap_blocker.py
@@ -517,7 +517,7 @@ class OverlapBlocker(Blocker):
             >>> A = em.read_csv_metadata('path_to_csv_dir/table_A.csv', key='ID')
             >>> B = em.read_csv_metadata('path_to_csv_dir/table_B.csv', key='ID')
             >>> ob = em.OverlapBlocker()
-            >>> status = ob.block_tuples(A.ix[0], B.ix[0], 'address', 'address')
+            >>> status = ob.block_tuples(A.loc[0], B.loc[0], 'address', 'address')
 
         """
 

--- a/py_entitymatching/blocker/rule_based_blocker.py
+++ b/py_entitymatching/blocker/rule_based_blocker.py
@@ -650,7 +650,7 @@ class RuleBasedBlocker(Blocker):
                 >>> block_f = em.get_features_for_blocking(A, B)
                 >>> rule = ['name_name_lev(ltuple, rtuple) > 3']
                 >>> rb.add_rule(rule, feature_table=block_f)
-                >>> D = rb.block_tuples(A.ix[0], B.ix[1)
+                >>> D = rb.block_tuples(A.loc[0], B.loc[1)
 
         """
 
@@ -916,13 +916,13 @@ def _block_candset_excluding_rule_split(c_df, l_df, r_df, l_key, r_key,
         # # get ltuple, try dictionary first, then dataframe
         row_lid = row[l_id_pos]
         if row_lid not in l_dict:
-            l_dict[row_lid] = l_df.ix[row_lid]
+            l_dict[row_lid] = l_df.loc[row_lid]
         ltuple = l_dict[row_lid]
 
         # # get rtuple, try dictionary first, then dataframe
         row_rid = row[r_id_pos]
         if row_rid not in r_dict:
-            r_dict[row_rid] = r_df.ix[row_rid]
+            r_dict[row_rid] = r_df.loc[row_rid]
         rtuple = r_dict[row_rid]
 
         res = apply_rules_excluding_rule(ltuple, rtuple, rule_to_exclude)

--- a/py_entitymatching/dask/dask_attr_equiv_blocker.py
+++ b/py_entitymatching/dask/dask_attr_equiv_blocker.py
@@ -421,7 +421,7 @@ class DaskAttrEquivalenceBlocker(Blocker):
             >>> ab = DaskAttrEquivalenceBlocker()            
             >>> A = em.read_csv_metadata('path_to_csv_dir/table_A.csv', key='ID')
             >>> B = em.read_csv_metadata('path_to_csv_dir/table_B.csv', key='ID')
-            >>> status = ab.block_tuples(A.ix[0], B.ix[0], 'zipcode', 'zipcode')
+            >>> status = ab.block_tuples(A.loc[0], B.loc[0], 'zipcode', 'zipcode')
         """
         l_val, r_val = ltuple[l_block_attr], rtuple[r_block_attr]
         if allow_missing:
@@ -541,12 +541,12 @@ def _block_candset_split(c_df, l_df, r_df, l_key, r_key,
         # # get the value of block attributes
         row_lkey = row[lkey_idx]
         if row_lkey not in l_dict:
-            l_dict[row_lkey] = l_df.ix[row_lkey, l_block_attr]
+            l_dict[row_lkey] = l_df.loc[row_lkey, l_block_attr]
         l_val = l_dict[row_lkey]
 
         row_rkey = row[rkey_idx]
         if row_rkey not in r_dict:
-            r_dict[row_rkey] = r_df.ix[row_rkey, r_block_attr]
+            r_dict[row_rkey] = r_df.loc[row_rkey, r_block_attr]
         r_val = r_dict[row_rkey]
 
         if allow_missing:

--- a/py_entitymatching/dask/dask_black_box_blocker.py
+++ b/py_entitymatching/dask/dask_black_box_blocker.py
@@ -418,7 +418,7 @@ class DaskBlackBoxBlocker(Blocker):
             >>> from py_entitymatching.dask.dask_black_box_blocker import DaskBlackBoxBlocker
             >>> bb = DaskBlackBoxBlocker()
             >>> bb.set_black_box_function(match_last_name)
-            >>> status = bb.block_tuples(A.ix[0], B.ix[0]) # A, B are input tables.
+            >>> status = bb.block_tuples(A.loc[0], B.loc[0]) # A, B are input tables.
 
         """
 
@@ -529,13 +529,13 @@ def _block_candset_split(c_df, l_df, r_df, l_key, r_key, fk_ltable, fk_rtable,
         # # get ltuple, try dictionary first, then dataframe
         row_lkey = row[l_id_pos]
         if row_lkey not in l_dict:
-            l_dict[row_lkey] = l_df.ix[row_lkey]
+            l_dict[row_lkey] = l_df.loc[row_lkey]
         ltuple = l_dict[row_lkey]
 
         # # get rtuple, try dictionary first, then dataframe
         row_rkey = row[r_id_pos]
         if row_rkey not in r_dict:
-            r_dict[row_rkey] = r_df.ix[row_rkey]
+            r_dict[row_rkey] = r_df.loc[row_rkey]
         rtuple = r_dict[row_rkey]
 
         # # apply the black box function to the tuple pair

--- a/py_entitymatching/dask/dask_overlap_blocker.py
+++ b/py_entitymatching/dask/dask_overlap_blocker.py
@@ -562,12 +562,12 @@ class DaskOverlapBlocker(Blocker):
         for row in c_df.itertuples(index=False):
             row_lkey = row[lkey_idx]
             if row_lkey not in l_dict:
-                l_dict[row_lkey] = l_df.ix[row_lkey, l_block_attr]
+                l_dict[row_lkey] = l_df.loc[row_lkey, l_block_attr]
             l_val = l_dict[row_lkey]
 
             row_rkey = row[rkey_idx]
             if row_rkey not in r_dict:
-                r_dict[row_rkey] = r_df.ix[row_rkey, r_block_attr]
+                r_dict[row_rkey] = r_df.loc[row_rkey, r_block_attr]
             r_val = r_dict[row_rkey]
             if allow_missing:
                 if pd.isnull(l_val) or pd.isnull(r_val) or l_val == r_val:
@@ -764,7 +764,7 @@ class DaskOverlapBlocker(Blocker):
             >>> A = em.read_csv_metadata('path_to_csv_dir/table_A.csv', key='ID')
             >>> B = em.read_csv_metadata('path_to_csv_dir/table_B.csv', key='ID')
             >>> ob = em.OverlapBlocker()
-            >>> status = ob.block_tuples(A.ix[0], B.ix[0], 'address', 'address')
+            >>> status = ob.block_tuples(A.loc[0], B.loc[0], 'address', 'address')
 
         """
 

--- a/py_entitymatching/dask/dask_rule_based_blocker.py
+++ b/py_entitymatching/dask/dask_rule_based_blocker.py
@@ -699,7 +699,7 @@ class DaskRuleBasedBlocker(Blocker):
                 >>> block_f = em.get_features_for_blocking(A, B)
                 >>> rule = ['name_name_lev(ltuple, rtuple) > 3']
                 >>> rb.add_rule(rule, feature_table=block_f)
-                >>> D = rb.block_tuples(A.ix[0], B.ix[1)
+                >>> D = rb.block_tuples(A.loc[0], B.loc[1)
         """
 
 
@@ -964,13 +964,13 @@ def _block_candset_excluding_rule_split(c_df, l_df, r_df, l_key, r_key,
         # # get ltuple, try dictionary first, then dataframe
         row_lid = row[l_id_pos]
         if row_lid not in l_dict:
-            l_dict[row_lid] = l_df.ix[row_lid]
+            l_dict[row_lid] = l_df.loc[row_lid]
         ltuple = l_dict[row_lid]
 
         # # get rtuple, try dictionary first, then dataframe
         row_rid = row[r_id_pos]
         if row_rid not in r_dict:
-            r_dict[row_rid] = r_df.ix[row_rid]
+            r_dict[row_rid] = r_df.loc[row_rid]
         rtuple = r_dict[row_rid]
 
         res = apply_rules_excluding_rule(ltuple, rtuple, rule_to_exclude)

--- a/py_entitymatching/debugblocker/backup_debugblocker.py
+++ b/py_entitymatching/debugblocker/backup_debugblocker.py
@@ -223,8 +223,8 @@ def _assemble_topk_table(topk_heap, ltable, rtable, ret_key='_id',
     ret_tuple_list = []
     for i in range(len(topk_heap)):
         tup = topk_heap[i]
-        lrecord = list(ltable.ix[tup[1]])
-        rrecord = list(rtable.ix[tup[2]])
+        lrecord = list(ltable.loc[tup[1]])
+        rrecord = list(rtable.loc[tup[2]])
         ret_tuple = [i, tup[0]]
         ret_tuple.append(lrecord[lkey_index])
         ret_tuple.append(rrecord[rkey_index])

--- a/py_entitymatching/debugblocker/debugblocker.py
+++ b/py_entitymatching/debugblocker/debugblocker.py
@@ -684,8 +684,8 @@ def _assemble_topk_table(rec_list, ltable, rtable, lkey, rkey, ret_key='_id',
     ret_tuple_list = []
     for i in range(len(rec_list)):
         tup = rec_list[i]
-        lrecord = list(ltable.ix[tup[1]])
-        rrecord = list(rtable.ix[tup[2]])
+        lrecord = list(ltable.loc[tup[1]])
+        rrecord = list(rtable.loc[tup[2]])
         ret_tuple = [i]
         ret_tuple.append(lrecord[lkey_index])
         ret_tuple.append(rrecord[rkey_index])

--- a/py_entitymatching/debugmatcher/debug_decisiontree_matcher.py
+++ b/py_entitymatching/debugmatcher/debug_decisiontree_matcher.py
@@ -191,7 +191,7 @@ def debug_decisiontree_matcher(decision_tree, tuple_1, tuple_2, feature_table,
         >>> # F is the feature vector got from evaluation set of the labeled data.
         >>> out = dt.predict(table=F, exclude_attrs=['_id', 'ltable_id', 'rtable_id', 'gold_labels'], target_attr='gold_labels')
         >>> # A and B are input tables
-        >>> em.debug_decisiontree_matcher(dt, A.ix[1], B.ix[2], match_f, H.columns, exclude_attrs=['_id', 'ltable_id', 'rtable_id', 'gold_labels'], target_attr='gold_labels')
+        >>> em.debug_decisiontree_matcher(dt, A.loc[1], B.loc[2], match_f, H.columns, exclude_attrs=['_id', 'ltable_id', 'rtable_id', 'gold_labels'], target_attr='gold_labels')
     """
 
     validate_object_type(feature_table, pd.DataFrame, 'The input feature table')

--- a/py_entitymatching/debugmatcher/debug_gui_decisiontree_matcher.py
+++ b/py_entitymatching/debugmatcher/debug_gui_decisiontree_matcher.py
@@ -169,7 +169,7 @@ def vis_tuple_debug_dt_matcher(matcher, t, exclude_attrs):
     code = _get_dbg_fn_vis(code)
 
     # Link the code with feature vaues
-    feat_vals = OrderedDict(t.ix[t.index.values[0], feature_names])
+    feat_vals = OrderedDict(t.loc[t.index.values[0], feature_names])
     wrapper_code = {}
     wrapper_code.update(feat_vals)
     six.exec_(code, wrapper_code)

--- a/py_entitymatching/debugmatcher/debug_gui_utils.py
+++ b/py_entitymatching/debugmatcher/debug_gui_utils.py
@@ -66,7 +66,7 @@ def _get_dataframe(table, ls):
         # Set the index on fk_ltable, fk_rtable
         table = table.set_index([fk_ltable, fk_rtable], drop=False)
         # Do the selection
-        d = table.ix[ls]
+        d = table.loc[ls]
         ret = d
         ret.reset_index(inplace=True, drop=True)
     # Finally return the selected values

--- a/py_entitymatching/debugmatcher/debug_randomforest_matcher.py
+++ b/py_entitymatching/debugmatcher/debug_randomforest_matcher.py
@@ -50,7 +50,7 @@ def debug_randomforest_matcher(random_forest, tuple_1, tuple_2,
         >>> # F is the feature vector got from evaluation set of the labeled data.
         >>> out = rf.predict(table=F, exclude_attrs=['_id', 'ltable_id', 'rtable_id', 'gold_labels'], target_attr='gold_labels')
         >>> # A and B are input tables
-        >>> em.debug_randomforest_matcher(rf, A.ix[1], B.ix[2], match_f, H.columns, exclude_attrs=['_id', 'ltable_id', 'rtable_id', 'gold_labels'], target_attr='gold_labels')
+        >>> em.debug_randomforest_matcher(rf, A.loc[1], B.loc[2], match_f, H.columns, exclude_attrs=['_id', 'ltable_id', 'rtable_id', 'gold_labels'], target_attr='gold_labels')
 
     """
     # Validate input parameters.

--- a/py_entitymatching/evaluation/evaluation.py
+++ b/py_entitymatching/evaluation/evaluation.py
@@ -169,8 +169,8 @@ def eval_matches(data_frame, gold_label_attr, predicted_label_attr):
     new_data_frame.set_index([fk_ltable, fk_rtable], drop=False, inplace=True)
 
     # Get the list of false positives and false negatives.
-    false_pos_ls = list(new_data_frame.ix[false_positive_indices].index.values)
-    false_neg_ls = list(new_data_frame.ix[false_negative_indices].index.values)
+    false_pos_ls = list(new_data_frame.iloc[false_positive_indices].index.values)
+    false_neg_ls = list(new_data_frame.iloc[false_negative_indices].index.values)
 
     # Store and return the accuracy results.
     accuracy_results = collections.OrderedDict()

--- a/py_entitymatching/feature/extractfeatures.py
+++ b/py_entitymatching/feature/extractfeatures.py
@@ -230,11 +230,11 @@ def get_feature_vals_by_cand_split(pickled_obj, fk_ltable_idx, fk_rtable_idx, l_
         fk_rtable_val = row[fk_rtable_idx]
 
         if fk_ltable_val not in l_dict:
-            l_dict[fk_ltable_val] = l_df.ix[fk_ltable_val]
+            l_dict[fk_ltable_val] = l_df.loc[fk_ltable_val]
         l_tuple = l_dict[fk_ltable_val]
 
         if fk_rtable_val not in r_dict:
-            r_dict[fk_rtable_val] = r_df.ix[fk_rtable_val]
+            r_dict[fk_rtable_val] = r_df.loc[fk_rtable_val]
         r_tuple = r_dict[fk_rtable_val]
 
         f = apply_feat_fns(l_tuple, r_tuple, feature_table)

--- a/py_entitymatching/gui/debug_gui_base.py
+++ b/py_entitymatching/gui/debug_gui_base.py
@@ -97,10 +97,10 @@ class MainWindowManager(QtWidgets.QWidget):
         # Handle debug, show the tree to the user
         l_fkey = cm.get_fk_ltable(self.table)
         r_fkey = cm.get_fk_rtable(self.table)
-        l_val = r.ix[r.index.values[0], l_fkey]
-        r_val = r.ix[r.index.values[0], r_fkey]
-        d1 = OrderedDict(self.l_df.ix[l_val])
-        d2 = OrderedDict(self.r_df.ix[r_val])
+        l_val = r.loc[r.index.values[0], l_fkey]
+        r_val = r.loc[r.index.values[0], r_fkey]
+        d1 = OrderedDict(self.l_df.loc[l_val])
+        d2 = OrderedDict(self.r_df.loc[r_val])
         if self.matcher_type == 'dt':
             ret_val, node_list = em.vis_tuple_debug_dt_matcher(
                 self.matcher, r,
@@ -125,10 +125,10 @@ class MainWindowManager(QtWidgets.QWidget):
         l_fkey = cm.get_fk_ltable(self.table)
         r_fkey = cm.get_fk_rtable(self.table)
 
-        l_val = r.ix[r.index.values[0], l_fkey]
-        r_val = r.ix[r.index.values[0], r_fkey]
-        d1 = OrderedDict(self.l_df.ix[l_val])
-        d2 = OrderedDict(self.r_df.ix[r_val])
+        l_val = r.loc[r.index.values[0], l_fkey]
+        r_val = r.loc[r.index.values[0], r_fkey]
+        d1 = OrderedDict(self.l_df.loc[l_val])
+        d2 = OrderedDict(self.r_df.loc[r_val])
         # Create a window manager
         show_obj = ShowWindowManager(d1, d2)
         # Show the window to the user

--- a/py_entitymatching/matcher/booleanrulematcher.py
+++ b/py_entitymatching/matcher/booleanrulematcher.py
@@ -55,8 +55,8 @@ class BooleanRuleMatcher(RuleMatcher):
 
         # # iterate through the cand. set
         for row in candset.itertuples(index=False):
-            l_row = l_df.ix[row[lid_idx]]
-            r_row = r_df.ix[row[rid_idx]]
+            l_row = l_df.loc[row[lid_idx]]
+            r_row = r_df.loc[row[rid_idx]]
             res = self.apply_rules(l_row, r_row)
             if res is True:
                 predictions.append(1)

--- a/py_entitymatching/matcher/matcherutils.py
+++ b/py_entitymatching/matcher/matcherutils.py
@@ -101,8 +101,8 @@ def split_train_test(labeled_data, train_proportion=0.5,
                                               random_state=random_state)
 
     # Construct output tables.
-    label_train = labeled_data.ix[idx_train]
-    label_test = labeled_data.ix[idx_test]
+    label_train = labeled_data.loc[idx_train]
+    label_test = labeled_data.loc[idx_test]
 
     # Update catalog
     cm.init_properties(label_train)

--- a/py_entitymatching/sampler/down_sample.py
+++ b/py_entitymatching/sampler/down_sample.py
@@ -344,7 +344,7 @@ def down_sample(table_a, table_b, size, y_param, show_progress=True,
 
     n_jobs = get_num_procs(n_jobs, len(table_b))
 
-    sample_table_b = table_b.ix[b_tbl_indices]
+    sample_table_b = table_b.loc[b_tbl_indices]
     if n_jobs <= 1:
         # Probe inverted index to find all tuples in A that share tokens with tuples in B'.
         s_tbl_indices = _probe_index_split(sample_table_b, y_param,

--- a/py_entitymatching/tests/_test_debug_matcher_dt.py
+++ b/py_entitymatching/tests/_test_debug_matcher_dt.py
@@ -17,7 +17,7 @@ from py_entitymatching.io.parsers import read_csv_metadata
 from py_entitymatching.matcher.dtmatcher import DTMatcher
 from py_entitymatching.utils.generic_helper import get_install_path
 
-datasets_path = os.sep.join([get_install_path(), 'datasets', 'test_datasets'])
+datasets_path = os.sep.join([get_install_path(), 'tests', 'test_datasets'])
 path_a = os.sep.join([datasets_path, 'A.csv'])
 path_b = os.sep.join([datasets_path, 'B.csv'])
 path_c = os.sep.join([datasets_path, 'C.csv'])
@@ -67,7 +67,7 @@ class VisDTDebugMatcherTestCases(unittest.TestCase):
         dt = DTMatcher()
         dt.fit(table=feature_vectors, exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'],
                target_attr='labels')
-        s = pd.DataFrame(feature_vectors.ix[0])
+        s = pd.DataFrame(feature_vectors.loc[0])
         s1 = s.T
         vis_tuple_debug_dt_matcher(dt, s1,
                                    exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'])
@@ -87,7 +87,7 @@ class VisDTDebugMatcherTestCases(unittest.TestCase):
         dt = DTMatcher()
         dt.fit(table=feature_vectors, exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'],
                target_attr='labels')
-        s = pd.DataFrame(feature_vectors.ix[0])
+        s = pd.DataFrame(feature_vectors.loc[0])
         s1 = s.T
         vis_tuple_debug_dt_matcher(dt.clf, s1,
                                    exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'])
@@ -108,7 +108,7 @@ class VisDTDebugMatcherTestCases(unittest.TestCase):
         dt.fit(table=feature_vectors, exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'],
                target_attr='labels')
         feature_vectors.drop(['_id', 'ltable_ID', 'rtable_ID', 'labels'], axis=1, inplace=True)
-        s = pd.DataFrame(feature_vectors.ix[0])
+        s = pd.DataFrame(feature_vectors.loc[0])
         s1 = s.T
 
         vis_tuple_debug_dt_matcher(dt.clf, s1, exclude_attrs=None)
@@ -292,6 +292,6 @@ class DTDebugMatcherTestCases(unittest.TestCase):
         dt = DTMatcher()
         dt.fit(table=feature_vectors, exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'],
                target_attr='labels')
-        debug_decisiontree_matcher(dt, A.ix[1], B.ix[2], feature_table=feature_table,
+        debug_decisiontree_matcher(dt, A.loc[1], B.loc[2], feature_table=feature_table,
                                    table_columns=feature_vectors.columns,
                                    exclude_attrs=['ltable_ID', 'rtable_ID', '_id', 'labels'])

--- a/py_entitymatching/tests/_test_debug_matcher_rf.py
+++ b/py_entitymatching/tests/_test_debug_matcher_rf.py
@@ -17,7 +17,7 @@ from py_entitymatching.io.parsers import read_csv_metadata
 from py_entitymatching.matcher.rfmatcher import RFMatcher
 from py_entitymatching.utils.generic_helper import get_install_path
 
-datasets_path = os.sep.join([get_install_path(), 'datasets', 'test_datasets'])
+datasets_path = os.sep.join([get_install_path(), 'tests', 'test_datasets'])
 path_a = os.sep.join([datasets_path, 'A.csv'])
 path_b = os.sep.join([datasets_path, 'B.csv'])
 path_c = os.sep.join([datasets_path, 'C.csv'])
@@ -67,7 +67,7 @@ class VisRFDebugMatcherTestCases(unittest.TestCase):
         rf = RFMatcher()
         rf.fit(table=feature_vectors, exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'],
                target_attr='labels')
-        s = pd.DataFrame(feature_vectors.ix[0])
+        s = pd.DataFrame(feature_vectors.loc[0])
         s1 = s.T
         vis_tuple_debug_rf_matcher(rf.clf, s1,
                                    exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'])
@@ -87,7 +87,7 @@ class VisRFDebugMatcherTestCases(unittest.TestCase):
         rf = RFMatcher()
         rf.fit(table=feature_vectors, exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'],
                target_attr='labels')
-        s = pd.DataFrame(feature_vectors.ix[0])
+        s = pd.DataFrame(feature_vectors.loc[0])
         s1 = s.T
         vis_tuple_debug_rf_matcher(rf, s1,
                                    exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'])
@@ -108,7 +108,7 @@ class VisRFDebugMatcherTestCases(unittest.TestCase):
         rf.fit(table=feature_vectors, exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'],
                target_attr='labels')
         feature_vectors.drop(['_id', 'ltable_ID', 'rtable_ID', 'labels'], axis=1, inplace=True)
-        s = pd.DataFrame(feature_vectors.ix[0])
+        s = pd.DataFrame(feature_vectors.loc[0])
         s1 = s.T
 
         vis_tuple_debug_rf_matcher(rf.clf, s1, exclude_attrs=None)
@@ -258,7 +258,7 @@ class RFDebugMatcherTestCases(unittest.TestCase):
     #     rf = RFMatcher()
     #     rf.fit(table=feature_vectors, exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'],
     #            target_attr='labels')
-    #     debug_randomforest_matcher(rf, A.ix[1], B.ix[2], feat_table=feature_table,
+    #     debug_randomforest_matcher(rf, A.loc[1], B.loc[2], feat_table=feature_table,
     #                           fv_columns=feature_vectors.columns,
     #                           exclude_attrs=['ltable_ID', 'rtable_ID', '_id', 'labels'])
 
@@ -278,7 +278,7 @@ class RFDebugMatcherTestCases(unittest.TestCase):
         rf.fit(table=feature_vectors, exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'],
                target_attr='labels')
 
-        debug_randomforest_matcher(rf, A.ix[1], B.ix[2], feature_table=None,
+        debug_randomforest_matcher(rf, A.loc[1], B.loc[2], feature_table=None,
                                    table_columns=feature_vectors.columns,
                                    exclude_attrs=['ltable_ID', 'rtable_ID', '_id', 'labels'])
 
@@ -298,6 +298,6 @@ class RFDebugMatcherTestCases(unittest.TestCase):
         rf.fit(table=feature_vectors, exclude_attrs=['_id', 'ltable_ID', 'rtable_ID', 'labels'],
                target_attr='labels')
 
-        debug_randomforest_matcher(rf.clf, A.ix[1], B.ix[2], feature_table=feature_table,
+        debug_randomforest_matcher(rf.clf, A.loc[1], B.loc[2], feature_table=feature_table,
                                    table_columns=feature_vectors.columns,
                                    exclude_attrs=['ltable_ID', 'rtable_ID', '_id', 'labels'])

--- a/py_entitymatching/tests/_test_matcherselector_mlmatcherselection_xg.py
+++ b/py_entitymatching/tests/_test_matcherselector_mlmatcherselection_xg.py
@@ -58,7 +58,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -97,7 +97,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -136,7 +136,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -175,7 +175,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -214,7 +214,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -253,7 +253,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -294,7 +294,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 

--- a/py_entitymatching/tests/test_attr_equiv_blocker.py
+++ b/py_entitymatching/tests/test_attr_equiv_blocker.py
@@ -524,10 +524,10 @@ class AttrEquivBlockerTestCases(unittest.TestCase):
 
 
     def test_ab_block_tuples(self):
-        assert_equal(self.ab.block_tuples(self.A.ix[1], self.B.ix[2],
+        assert_equal(self.ab.block_tuples(self.A.loc[1], self.B.loc[2],
                                           l_block_attr_1, r_block_attr_1),
                      False)
-        assert_equal(self.ab.block_tuples(self.A.ix[2], self.B.ix[2],
+        assert_equal(self.ab.block_tuples(self.A.loc[2], self.B.loc[2],
                                           l_block_attr_1, r_block_attr_1),
                      True)
 
@@ -540,19 +540,19 @@ class AttrEquivBlockerTestCases(unittest.TestCase):
         em.set_key(A, 'ID')
         B = em.read_csv_metadata(path_b)
         em.set_key(B, 'ID')
-        assert_equal(self.ab.block_tuples(A.ix[0], B.ix[0], l_block_attr_1,
+        assert_equal(self.ab.block_tuples(A.loc[0], B.loc[0], l_block_attr_1,
                                           r_block_attr_1, allow_missing=True),
                      False)
-        assert_equal(self.ab.block_tuples(A.ix[1], B.ix[2], l_block_attr_1,
+        assert_equal(self.ab.block_tuples(A.loc[1], B.loc[2], l_block_attr_1,
                                           r_block_attr_1, allow_missing=True),
                      False)
-        assert_equal(self.ab.block_tuples(A.ix[2], B.ix[1], l_block_attr_1,
+        assert_equal(self.ab.block_tuples(A.loc[2], B.loc[1], l_block_attr_1,
                                           r_block_attr_1, allow_missing=True),
                      False)
-        assert_equal(self.ab.block_tuples(A.ix[0], B.ix[1], l_block_attr_1,
+        assert_equal(self.ab.block_tuples(A.loc[0], B.loc[1], l_block_attr_1,
                                           r_block_attr_1, allow_missing=True),
                      False)
-        assert_equal(self.ab.block_tuples(A.ix[2], B.ix[2], l_block_attr_1,
+        assert_equal(self.ab.block_tuples(A.loc[2], B.loc[2], l_block_attr_1,
                                           r_block_attr_1, allow_missing=True),
                      True)
 
@@ -565,15 +565,15 @@ class AttrEquivBlockerTestCases(unittest.TestCase):
         em.set_key(A, 'ID')
         B = em.read_csv_metadata(path_b)
         em.set_key(B, 'ID')
-        assert_equal(self.ab.block_tuples(A.ix[0], B.ix[0], l_block_attr_1,
+        assert_equal(self.ab.block_tuples(A.loc[0], B.loc[0], l_block_attr_1,
                                           r_block_attr_1), True)
-        assert_equal(self.ab.block_tuples(A.ix[1], B.ix[2], l_block_attr_1,
+        assert_equal(self.ab.block_tuples(A.loc[1], B.loc[2], l_block_attr_1,
                                           r_block_attr_1), False)
-        assert_equal(self.ab.block_tuples(A.ix[2], B.ix[1], l_block_attr_1,
+        assert_equal(self.ab.block_tuples(A.loc[2], B.loc[1], l_block_attr_1,
                                           r_block_attr_1), True)
-        assert_equal(self.ab.block_tuples(A.ix[0], B.ix[1], l_block_attr_1,
+        assert_equal(self.ab.block_tuples(A.loc[0], B.loc[1], l_block_attr_1,
                                           r_block_attr_1), True)
-        assert_equal(self.ab.block_tuples(A.ix[2], B.ix[2], l_block_attr_1,
+        assert_equal(self.ab.block_tuples(A.loc[2], B.loc[2], l_block_attr_1,
                                           r_block_attr_1), True)
 
 

--- a/py_entitymatching/tests/test_black_box_blocker.py
+++ b/py_entitymatching/tests/test_black_box_blocker.py
@@ -278,9 +278,9 @@ class BlackBoxBlockerTestCases(unittest.TestCase):
 
     def test_bb_block_tuples(self):
         self.bb.set_black_box_function(_block_fn)
-        assert_equal(self.bb.block_tuples(self.A.ix[1], self.B.ix[2]),
+        assert_equal(self.bb.block_tuples(self.A.loc[1], self.B.loc[2]),
                      False)
-        assert_equal(self.bb.block_tuples(self.A.ix[2], self.B.ix[2]),
+        assert_equal(self.bb.block_tuples(self.A.loc[2], self.B.loc[2]),
                      True)
 
 

--- a/py_entitymatching/tests/test_catalog.py
+++ b/py_entitymatching/tests/test_catalog.py
@@ -906,7 +906,7 @@ class CatalogManagerTestCases(unittest.TestCase):
         A = pd.read_csv(path_a)
         B = pd.read_csv(path_b)
         C = pd.read_csv(path_c)
-        C.ix[0, 'ltable_ID'] = pd.np.NaN
+        C.loc[0, 'ltable_ID'] = pd.np.NaN
         status = ch.check_fk_constraint(C, 'ltable_ID', A, 'ID')
         self.assertEqual(status, False)
 

--- a/py_entitymatching/tests/test_debugblocker.py
+++ b/py_entitymatching/tests/test_debugblocker.py
@@ -631,7 +631,7 @@ class DebugblockerTestCases(unittest.TestCase):
         r_key = cm.get_key(B)
         C = read_csv_metadata(path_c, ltable=A, rtable=B, fk_ltable='ltable_' +
                 l_key, fk_rtable='rtable_' + r_key, key = '_id')
-        C.ix[0, 'ltable_ID'] = 'aaaa'
+        C.loc[0, 'ltable_ID'] = 'aaaa'
 
         lrecord_id_to_index_map = db._build_id_to_index_map(A, l_key)
         rrecord_id_to_index_map = db._build_id_to_index_map(B, r_key)
@@ -647,7 +647,7 @@ class DebugblockerTestCases(unittest.TestCase):
         r_key = cm.get_key(B)
         C = read_csv_metadata(path_c, ltable=A, rtable=B, fk_ltable='ltable_' +
                 l_key, fk_rtable='rtable_' + r_key, key = '_id')
-        C.ix[0, 'rtable_ID'] = 'bbbb'
+        C.loc[0, 'rtable_ID'] = 'bbbb'
 
         lrecord_id_to_index_map = db._build_id_to_index_map(A, l_key)
         rrecord_id_to_index_map = db._build_id_to_index_map(B, r_key)
@@ -785,9 +785,9 @@ class DebugblockerTestCases(unittest.TestCase):
                           1989, 30.0, '607 From St, San Francisco', 94107,
                           'Joseph Kuan', 1982, 26.0,
                           '108 South Park, San Francisco', 94122]]
-        self.assertEqual(list(ret_dataframe.ix[0]), expected_recs[0])
-        self.assertEqual(list(ret_dataframe.ix[1]), expected_recs[1])
-        self.assertEqual(list(ret_dataframe.ix[2]), expected_recs[2])
+        self.assertEqual(list(ret_dataframe.loc[0]), expected_recs[0])
+        self.assertEqual(list(ret_dataframe.loc[1]), expected_recs[1])
+        self.assertEqual(list(ret_dataframe.loc[2]), expected_recs[2])
     
     def test_debugblocker_config_cython_1(self):
         ltable_field_token_sum = {1}
@@ -1067,7 +1067,7 @@ class DebugblockerTestCases(unittest.TestCase):
                             'rtable_pub_year', 'rtable_language',
                             'rtable_author', 'rtable_publisher']
         self.assertEqual(list(ret_dataframe.columns), expected_columns)
-        ret_record = list(ret_dataframe.ix[0])
+        ret_record = list(ret_dataframe.loc[0])
         expected_record = [0, 1, 'B001', 'data analysis', 'introduction to data analysis',
             2015, 'ENG', 'Jane Doe', 'BCD publisher', 'introduction to data analysis', 
             float('nan'), 'English', 'introduction to data analysis', 'John Doe', 'ABC publisher10.00']

--- a/py_entitymatching/tests/test_feature_addfeatures.py
+++ b/py_entitymatching/tests/test_feature_addfeatures.py
@@ -36,7 +36,7 @@ class AddFeaturesTestCases(unittest.TestCase):
         add_feature(feature_table, 'test', f_dict)
         len2 = len(feature_table)
         self.assertEqual(len1+1, len2)
-        self.assertEqual(feature_table.ix[len(feature_table)-1, 'function'](A.ix[1], B.ix[2]), 1.0)
+        self.assertEqual(feature_table.loc[len(feature_table)-1, 'function'](A.loc[1], B.loc[2]), 1.0)
 
 
     def test_feature_fn_valid_nosim_tok(self):
@@ -119,7 +119,7 @@ class AddFeaturesTestCases(unittest.TestCase):
         add_feature(feature_table, 'test', f_dict)
         len2 = len(feature_table)
         self.assertEqual(len1+1, len2)
-        self.assertEqual(feature_table.ix[len(feature_table)-1, 'function'](A.ix[1], B.ix[2]), 1.0)
+        self.assertEqual(feature_table.loc[len(feature_table)-1, 'function'](A.loc[1], B.loc[2]), 1.0)
 
     @raises(AssertionError)
     def test_add_feature_invalid_df(self):
@@ -180,7 +180,7 @@ class AddBlackBoxFeatureTestCases(unittest.TestCase):
         add_blackbox_feature(feature_table, 'test', bb_fn)
         len2 = len(feature_table)
         self.assertEqual(len1+1, len2)
-        self.assertEqual(feature_table.ix[len(feature_table)-1, 'function'](A.ix[1], B.ix[2]), 1.0)
+        self.assertEqual(feature_table.loc[len(feature_table)-1, 'function'](A.loc[1], B.loc[2]), 1.0)
 
     def test_add_bb_feature_valid_2(self):
         A = read_csv_metadata(path_a)
@@ -192,7 +192,7 @@ class AddBlackBoxFeatureTestCases(unittest.TestCase):
         add_blackbox_feature(feature_table, 'test', bb_fn)
         len2 = len(feature_table)
         self.assertEqual(len1+1, len2)
-        self.assertEqual(feature_table.ix[len(feature_table)-1, 'function'](A.ix[1], B.ix[2]), 1.0)
+        self.assertEqual(feature_table.loc[len(feature_table)-1, 'function'](A.loc[1], B.loc[2]), 1.0)
 
     @raises(AssertionError)
     def test_add_bb_feature_invalid_df(self):

--- a/py_entitymatching/tests/test_feature_attributeutils.py
+++ b/py_entitymatching/tests/test_feature_attributeutils.py
@@ -74,7 +74,7 @@ class AttributeUtilsTestCases(unittest.TestCase):
     @raises(AssertionError)
     def test_get_type_multiple_types(self):
         A = read_csv_metadata(path_a)
-        A.ix[0, 'ID'] = 1000
+        A.loc[0, 'ID'] = 1000
         t = _get_type(A['ID'])
 
     def test_get_type_valid_2(self):

--- a/py_entitymatching/tests/test_feature_autofeaturegen.py
+++ b/py_entitymatching/tests/test_feature_autofeaturegen.py
@@ -50,7 +50,7 @@ class AutoFeatureGenerationTestCases(unittest.TestCase):
         self.assertEqual(isinstance(feat_table, pd.DataFrame), True)
         functions = feat_table['function']
         for f in functions:
-            x = f(A.ix[1], B.ix[2])
+            x = f(A.loc[1], B.loc[2])
             self.assertEqual(x >= 0, True)
 
     @raises(AssertionError)
@@ -94,7 +94,7 @@ class AutoFeatureGenerationTestCases(unittest.TestCase):
         self.assertEqual(isinstance(feat_table, pd.DataFrame), True)
         functions = feat_table['function']
         for f in functions:
-            x = f(A.ix[1], B.ix[2])
+            x = f(A.loc[1], B.loc[2])
             self.assertEqual(x >= 0, True)
 
     @raises(AssertionError)
@@ -116,7 +116,7 @@ class AutoFeatureGenerationTestCases(unittest.TestCase):
         self.assertEqual(isinstance(feat_table, pd.DataFrame), True)
         functions = feat_table['function']
         for f in functions:
-            x = f(A.ix[1], B.ix[2])
+            x = f(A.loc[1], B.loc[2])
             self.assertEqual(x >= 0, True)
 
     @raises(AssertionError)
@@ -353,7 +353,7 @@ class AutoFeatureGenerationTestCases(unittest.TestCase):
 #         self.assertEqual(isinstance(feat_table, pd.DataFrame), True)
 #         functions = feat_table['function']
 #         for f in functions:
-#             x = f(A.ix[1], B.ix[2])
+#             x = f(A.loc[1], B.loc[2])
 #             self.assertEqual(x >= 0, True)
 
 #     def test_get_features_for_matching_validate_types_valid_yes(self):
@@ -366,7 +366,7 @@ class AutoFeatureGenerationTestCases(unittest.TestCase):
 #         self.assertEqual(isinstance(feat_table, pd.DataFrame), True)
 #         functions = feat_table['function']
 #         for f in functions:
-#             x = f(A.ix[1], B.ix[2])
+#             x = f(A.loc[1], B.loc[2])
 #             self.assertEqual(x >= 0, True)
 
 #     def test_get_features_for_blocking_validate_types_valid_no(self):

--- a/py_entitymatching/tests/test_matcherselector_mlmatcherselection.py
+++ b/py_entitymatching/tests/test_matcherselector_mlmatcherselection.py
@@ -58,7 +58,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -94,7 +94,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -130,7 +130,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -166,7 +166,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -202,7 +202,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -237,7 +237,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -276,7 +276,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -408,7 +408,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df_r.columns[[0, 1, 2]])), True)
         self.assertEqual('Mean score', result_df_p.columns[len(result_df_r.columns) - 1])
         d = result_df_p.set_index('Name')
-        p_max = d.ix[result['selected_matcher'].name, 'Mean score']
+        p_max = d.loc[result['selected_matcher'].name, 'Mean score']
         a_max = pd.np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -432,7 +432,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         result_df_p = result['drill_down_cv_stats']['precision']
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2, 3]])), True)
         d = result_df.set_index('Matcher')
-        p_max = d.ix[result['selected_matcher'].name, 'Average precision']
+        p_max = d.loc[result['selected_matcher'].name, 'Average precision']
         a_max = pd.np.max(result_df_p['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -458,7 +458,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         result_df_r = result['drill_down_cv_stats']['recall']
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         d = result_df.set_index('Matcher')
-        p_max = d.ix[result['selected_matcher'].name, 'Average recall']
+        p_max = d.loc[result['selected_matcher'].name, 'Average recall']
         a_max = pd.np.max(result_df_r['Mean score'])
         self.assertEqual(p_max, a_max)
 
@@ -484,7 +484,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         result_df_r = result['drill_down_cv_stats']['recall']
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1]])), True)
         d = result_df.set_index('Matcher')
-        p_max = d.ix[result['selected_matcher'].name, 'Average recall']
+        p_max = d.loc[result['selected_matcher'].name, 'Average recall']
         a_max = pd.np.max(result_df_r['Mean score'])
         self.assertEqual(p_max, a_max)
 

--- a/py_entitymatching/tests/test_overlap_blocker.py
+++ b/py_entitymatching/tests/test_overlap_blocker.py
@@ -586,19 +586,19 @@ class OverlapBlockerTestCases(unittest.TestCase):
         validate_data(D, expected_ids_2)
 
     def test_ob_block_tuples_whitespace(self):
-        assert_equal(self.ob.block_tuples(self.A.ix[1], self.B.ix[2],
+        assert_equal(self.ob.block_tuples(self.A.loc[1], self.B.loc[2],
                                           l_overlap_attr_1, r_overlap_attr_1),
                      False)
-        assert_equal(self.ob.block_tuples(self.A.ix[2], self.B.ix[2],
+        assert_equal(self.ob.block_tuples(self.A.loc[2], self.B.loc[2],
                                           l_overlap_attr_1, r_overlap_attr_1),
                      True)
 
     def test_ob_block_tuples_qgram(self):
-        assert_equal(self.ob.block_tuples(self.A.ix[1], self.B.ix[2],
+        assert_equal(self.ob.block_tuples(self.A.loc[1], self.B.loc[2],
                                           l_overlap_attr_1, r_overlap_attr_1,
                                           q_val=3, word_level=False),
                      False)
-        assert_equal(self.ob.block_tuples(self.A.ix[0], self.B.ix[0],
+        assert_equal(self.ob.block_tuples(self.A.loc[0], self.B.loc[0],
                                           l_overlap_attr_1, r_overlap_attr_1,
                                           q_val=3, word_level=False),
                      True)
@@ -612,16 +612,16 @@ class OverlapBlockerTestCases(unittest.TestCase):
         em.set_key(A, 'ID')
         B = em.read_csv_metadata(path_b)
         em.set_key(B, 'ID')
-        assert_equal(self.ob.block_tuples(A.ix[1], B.ix[3], l_overlap_attr_1,
+        assert_equal(self.ob.block_tuples(A.loc[1], B.loc[3], l_overlap_attr_1,
                                           r_overlap_attr_1, allow_missing=True),
                      False)
-        assert_equal(self.ob.block_tuples(A.ix[3], B.ix[2], l_overlap_attr_1,
+        assert_equal(self.ob.block_tuples(A.loc[3], B.loc[2], l_overlap_attr_1,
                                           r_overlap_attr_1, allow_missing=True),
                      False)
-        assert_equal(self.ob.block_tuples(A.ix[3], B.ix[3], l_overlap_attr_1,
+        assert_equal(self.ob.block_tuples(A.loc[3], B.loc[3], l_overlap_attr_1,
                                           r_overlap_attr_1, allow_missing=True),
                      False)
-        assert_equal(self.ob.block_tuples(A.ix[2], B.ix[2], l_overlap_attr_1,
+        assert_equal(self.ob.block_tuples(A.loc[2], B.loc[2], l_overlap_attr_1,
                                           r_overlap_attr_1, allow_missing=True),
                      True)
 
@@ -634,11 +634,11 @@ class OverlapBlockerTestCases(unittest.TestCase):
         em.set_key(A, 'ID')
         B = em.read_csv_metadata(path_b)
         em.set_key(B, 'ID')
-        assert_equal(self.ob.block_tuples(A.ix[1], B.ix[3], l_overlap_attr_1,
+        assert_equal(self.ob.block_tuples(A.loc[1], B.loc[3], l_overlap_attr_1,
                                           r_overlap_attr_1), True)
-        assert_equal(self.ob.block_tuples(A.ix[3], B.ix[2], l_overlap_attr_1,
+        assert_equal(self.ob.block_tuples(A.loc[3], B.loc[2], l_overlap_attr_1,
                                           r_overlap_attr_1), True)
-        assert_equal(self.ob.block_tuples(A.ix[3], B.ix[3], l_overlap_attr_1,
+        assert_equal(self.ob.block_tuples(A.loc[3], B.loc[3], l_overlap_attr_1,
                                           r_overlap_attr_1), True)
 
 

--- a/py_entitymatching/tests/test_rule_based_blocker.py
+++ b/py_entitymatching/tests/test_rule_based_blocker.py
@@ -499,8 +499,8 @@ class RuleBasedBlockerTestCases(unittest.TestCase):
      
     def test_rb_block_tuples(self):
         self.rb.add_rule(rule_1, self.feature_table)
-        assert_equal(self.rb.block_tuples(self.A.ix[1], self.B.ix[2]), False)
-        assert_equal(self.rb.block_tuples(self.A.ix[2], self.B.ix[2]), True)
+        assert_equal(self.rb.block_tuples(self.A.loc[1], self.B.loc[2]), False)
+        assert_equal(self.rb.block_tuples(self.A.loc[2], self.B.loc[2]), True)
 
     def test_rb_add_rule_user_supplied_rule_name(self):
         rule_name = self.rb.add_rule(rule_1, self.feature_table, 'myrule')

--- a/py_entitymatching/triggers/matchtrigger.py
+++ b/py_entitymatching/triggers/matchtrigger.py
@@ -233,8 +233,8 @@ class MatchTrigger(object):
         idx = 0
         for row in input_table.itertuples(index=False):
             if row[label_idx] != self.value_to_set:
-                l_row = l_tbl.ix[row[lid_idx]]
-                r_row = r_tbl.ix[row[rid_idx]]
+                l_row = l_tbl.loc[row[lid_idx]]
+                r_row = r_tbl.loc[row[rid_idx]]
                 res = self.apply_rules(l_row, r_row)
                 if res == self.cond_status:
                     table.iat[idx, label_idx] = self.value_to_set

--- a/py_entitymatching/utils/generic_helper.py
+++ b/py_entitymatching/utils/generic_helper.py
@@ -67,7 +67,7 @@ def rem_nan(table, attr):
         raise KeyError('Input attr. not in the table columns')
 
     l = table.index.values[pd.np.where(table[attr].notnull())[0]]
-    return table.ix[l]
+    return table.loc[l]
 
 
 def list_drop_duplicates(lst):
@@ -177,7 +177,7 @@ def create_proj_dataframe(df, key, key_vals, attrs, col_names):
 
 
     df = df.set_index(key, drop=False)
-    df = df.ix[key_vals, attrs]
+    df = df.loc[key_vals, attrs]
     df.reset_index(drop=True, inplace=True)
     df.columns = col_names
     return df
@@ -225,11 +225,11 @@ def parse_conjunct(conjunct, feature_table):
     threshold = vals3[1].strip()
     ft_df = feature_table.set_index('feature_name')
 
-    return (ft_df.ix[feature_name]['is_auto_generated'],
-            ft_df.ix[feature_name]['simfunction'],
-            ft_df.ix[feature_name]['left_attribute'],
-            ft_df.ix[feature_name]['right_attribute'],
-            ft_df.ix[feature_name]['left_attr_tokenizer'],
-            ft_df.ix[feature_name]['right_attr_tokenizer'],
+    return (ft_df.loc[feature_name]['is_auto_generated'],
+            ft_df.loc[feature_name]['simfunction'],
+            ft_df.loc[feature_name]['left_attribute'],
+            ft_df.loc[feature_name]['right_attribute'],
+            ft_df.loc[feature_name]['left_attr_tokenizer'],
+            ft_df.loc[feature_name]['right_attr_tokenizer'],
             operator, threshold)
 


### PR DESCRIPTION
This PR updates usage of the recently unsupported indexer DataFrame.ix to its undeprecated counterparts DataFrame.loc or DataFrame.iloc; see issue #134 for details.