### PR TITLE
fix: switch from pandas.np to use numpy directly

### DIFF
--- a/py_entitymatching/blocker/attr_equiv_blocker.py
+++ b/py_entitymatching/blocker/attr_equiv_blocker.py
@@ -1,6 +1,7 @@
 import logging
 
 import pandas as pd
+import numpy as np
 import pyprind
 import six
 from joblib import Parallel, delayed
@@ -185,8 +186,8 @@ class AttrEquivalenceBlocker(Blocker):
         else:
             # multiprocessing
             m, n = self.get_split_params(n_procs, len(l_df), len(r_df))
-            l_splits = pd.np.array_split(l_df, m)
-            r_splits = pd.np.array_split(r_df, n)
+            l_splits = np.array_split(l_df, m)
+            r_splits = np.array_split(r_df, n)
             c_splits = Parallel(n_jobs=m * n)(
                 delayed(_block_tables_split)(l, r, l_key, r_key,
                                              l_block_attr, r_block_attr,
@@ -335,7 +336,7 @@ class AttrEquivalenceBlocker(Blocker):
                                          l_block_attr, r_block_attr, fk_ltable,
                                          fk_rtable, allow_missing, show_progress)
         else:
-            c_splits = pd.np.array_split(candset, n_procs)
+            c_splits = np.array_split(candset, n_procs)
             valid_splits = Parallel(n_jobs=n_procs)(
                 delayed(_block_candset_split)(c_splits[i],
                                               l_df, r_df,
@@ -431,8 +432,8 @@ class AttrEquivalenceBlocker(Blocker):
                                      l_output_prefix, r_output_prefix):
 
         l_df.is_copy, r_df.is_copy = False, False  # to avoid setwithcopy warning
-        l_df['ones'] = pd.np.ones(len(l_df))
-        r_df['ones'] = pd.np.ones(len(r_df))
+        l_df['ones'] = np.ones(len(l_df))
+        r_df['ones'] = np.ones(len(r_df))
 
         # find ltable records with missing value in l_block_attr
         l_df_missing = l_df[pd.isnull(l_df[l_block_attr])]

--- a/py_entitymatching/blocker/black_box_blocker.py
+++ b/py_entitymatching/blocker/black_box_blocker.py
@@ -4,6 +4,7 @@ import time
 import sys
 
 import pandas as pd
+import numpy as np
 import pyprind
 from joblib import Parallel, delayed
 import cloudpickle as cp
@@ -186,8 +187,8 @@ class BlackBoxBlocker(Blocker):
         else:
             # multiprocessing
             m, n = self.get_split_params(n_procs, len(l_df), len(r_df))
-            l_splits = pd.np.array_split(l_df, m)
-            r_splits = pd.np.array_split(r_df, n)
+            l_splits = np.array_split(l_df, m)
+            r_splits = np.array_split(r_df, n)
             c_splits = Parallel(n_jobs=m*n)(delayed(_block_tables_split)(l_splits[i], r_splits[j],
                                                 l_key, r_key, 
                                                 l_output_attrs_1, r_output_attrs_1,
@@ -317,7 +318,7 @@ class BlackBoxBlocker(Blocker):
                                          black_box_function_pkl, show_progress)
         else:
             # multiprocessing
-            c_splits = pd.np.array_split(c_df, n_procs)
+            c_splits = np.array_split(c_df, n_procs)
             valid_splits = Parallel(n_jobs=n_procs)(delayed(_block_candset_split)(c_splits[i],
                                                             l_df, r_df,
                                                             l_key, r_key,

--- a/py_entitymatching/blocker/rule_based_blocker.py
+++ b/py_entitymatching/blocker/rule_based_blocker.py
@@ -2,6 +2,7 @@ import logging
 from collections import OrderedDict
 
 import pandas as pd
+import numpy as np
 import pyprind
 import six
 from joblib import Parallel, delayed
@@ -460,7 +461,7 @@ class RuleBasedBlocker(Blocker):
                                                         show_progress)
         else:
             # multiprocessing
-            c_splits = pd.np.array_split(c_df, n_procs)
+            c_splits = np.array_split(c_df, n_procs)
             valid_splits = Parallel(n_jobs=n_procs)(
                 delayed(_block_candset_excluding_rule_split)(c_splits[i],
                                                              l_df, r_df,
@@ -506,8 +507,8 @@ class RuleBasedBlocker(Blocker):
         else:
             # multiprocessing
             m, n = self.get_split_params(n_procs, len(l_df), len(r_df))
-            l_splits = pd.np.array_split(l_df, m)
-            r_splits = pd.np.array_split(r_df, n)
+            l_splits = np.array_split(l_df, m)
+            r_splits = np.array_split(r_df, n)
             c_splits = Parallel(n_jobs=m * n)(
                 delayed(_block_tables_split)(l_splits[i], r_splits[j],
                                              l_key, r_key,

--- a/py_entitymatching/blocker/sn_blocker.py
+++ b/py_entitymatching/blocker/sn_blocker.py
@@ -2,6 +2,7 @@ import logging
 
 import sys
 import pandas as pd
+import numpy as np
 import pyprind
 import six
 import warnings
@@ -190,8 +191,8 @@ class SortedNeighborhoodBlocker(Blocker):
             # Split l and r into n_procs chunks.
             # each core will get an l and an r, merge them, sort them.
 
-            l_splits = pd.np.array_split(ltable, n_procs)
-            r_splits = pd.np.array_split(rtable, n_procs)
+            l_splits = np.array_split(ltable, n_procs)
+            r_splits = np.array_split(rtable, n_procs)
 
             p_answer = Parallel(n_jobs=n_procs)(
                 delayed(_sn_block_tables_split)(l_splits[i], r_splits[i], l_key, r_key,

--- a/py_entitymatching/dask/dask_attr_equiv_blocker.py
+++ b/py_entitymatching/dask/dask_attr_equiv_blocker.py
@@ -1,6 +1,7 @@
 import logging
 
 import pandas as pd
+import numpy as np
 import pyprind
 import six
 
@@ -205,8 +206,8 @@ class DaskAttrEquivalenceBlocker(Blocker):
                                           l_output_prefix, r_output_prefix,
                                           allow_missing)
         else:
-            l_splits = pd.np.array_split(l_df, n_ltable_chunks)
-            r_splits = pd.np.array_split(r_df, n_rtable_chunks)
+            l_splits = np.array_split(l_df, n_ltable_chunks)
+            r_splits = np.array_split(r_df, n_rtable_chunks)
             c_splits = []
 
             for l in l_splits:
@@ -356,7 +357,7 @@ class DaskAttrEquivalenceBlocker(Blocker):
                                          l_block_attr, r_block_attr, fk_ltable,
                                          fk_rtable, allow_missing, show_progress)
         else:
-            c_splits = pd.np.array_split(candset, n_chunks)
+            c_splits = np.array_split(candset, n_chunks)
 
             valid_splits = []
             for i in range(len(c_splits)):
@@ -461,8 +462,8 @@ class DaskAttrEquivalenceBlocker(Blocker):
                                      l_output_prefix, r_output_prefix):
 
         l_df.is_copy, r_df.is_copy = False, False  # to avoid setwithcopy warning
-        l_df['ones'] = pd.np.ones(len(l_df))
-        r_df['ones'] = pd.np.ones(len(r_df))
+        l_df['ones'] = np.ones(len(l_df))
+        r_df['ones'] = np.ones(len(r_df))
 
         # find ltable records with missing value in l_block_attr
         l_df_missing = l_df[pd.isnull(l_df[l_block_attr])]

--- a/py_entitymatching/dask/dask_black_box_blocker.py
+++ b/py_entitymatching/dask/dask_black_box_blocker.py
@@ -4,6 +4,7 @@ import time
 import sys
 
 import pandas as pd
+import numpy as np
 import pyprind
 
 import dask
@@ -207,8 +208,8 @@ class DaskBlackBoxBlocker(Blocker):
                                           black_box_function_pkl, show_progress)
         else:
             # multiprocessing
-            l_splits = pd.np.array_split(l_df, n_ltable_chunks)
-            r_splits = pd.np.array_split(r_df, n_rtable_chunks)
+            l_splits = np.array_split(l_df, n_ltable_chunks)
+            r_splits = np.array_split(r_df, n_rtable_chunks)
 
             c_splits = []
             for i in range(len(l_splits)):
@@ -353,7 +354,7 @@ class DaskBlackBoxBlocker(Blocker):
                                          black_box_function_pkl, show_progress)
         else:
             # multiprocessing
-            c_splits = pd.np.array_split(c_df, n_chunks)
+            c_splits = np.array_split(c_df, n_chunks)
 
             valid_splits = []
             for i in range(len(c_splits)):

--- a/py_entitymatching/dask/dask_down_sample.py
+++ b/py_entitymatching/dask/dask_down_sample.py
@@ -9,6 +9,7 @@ import re
 from collections import Counter
 
 import pandas as pd
+import numpy as np
 from dask import delayed
 from dask.diagnostics import ProgressBar
 
@@ -144,7 +145,7 @@ def dask_down_sample(ltable, rtable, size, y_param, show_progress=True, verbose=
     if n_ltable_chunks == -1:
         n_ltable_chunks = get_num_cores()
 
-    ltable_chunks = pd.np.array_split(proj_ltable, n_ltable_chunks)
+    ltable_chunks = np.array_split(proj_ltable, n_ltable_chunks)
     preprocessed_tokenized_tbl = []
 
     # Use Dask to preprocess and tokenize strings.
@@ -188,7 +189,7 @@ def dask_down_sample(ltable, rtable, size, y_param, show_progress=True, verbose=
     if n_sample_rtable_chunks == -1:
         n_sample_rtable_chunks = get_num_cores()
 
-    rtable_chunks = pd.np.array_split(proj_rtable_sampled, n_sample_rtable_chunks)
+    rtable_chunks = np.array_split(proj_rtable_sampled, n_sample_rtable_chunks)
     probe_result = []
 
     # Create the DAG

--- a/py_entitymatching/dask/dask_extract_features.py
+++ b/py_entitymatching/dask/dask_extract_features.py
@@ -3,6 +3,7 @@ import os
 
 import pandas as pd
 import multiprocessing
+import numpy as np
 
 import dask
 from dask.diagnostics import ProgressBar
@@ -176,7 +177,7 @@ def dask_extract_feature_vecs(candset, attrs_before=None, feature_table=None,
 
     n_chunks = get_num_partitions(n_chunks, len(candset))
 
-    c_splits = pd.np.array_split(candset, n_chunks)
+    c_splits = np.array_split(candset, n_chunks)
 
     pickled_obj = cloudpickle.dumps(feature_table)
 

--- a/py_entitymatching/dask/dask_overlap_blocker.py
+++ b/py_entitymatching/dask/dask_overlap_blocker.py
@@ -5,6 +5,7 @@ from dask.diagnostics import ProgressBar
 import logging
 import multiprocessing
 import pandas as pd
+import numpy as np
 import re
 import six
 import string
@@ -237,7 +238,7 @@ class DaskOverlapBlocker(Blocker):
             n_ltable_chunks = multiprocessing.cpu_count()
 
 
-        ltable_chunks = pd.np.array_split(ltable, n_ltable_chunks)
+        ltable_chunks = np.array_split(ltable, n_ltable_chunks)
 
         # preprocess/tokenize ltable
         if word_level == True:
@@ -278,7 +279,7 @@ class DaskOverlapBlocker(Blocker):
         if n_rtable_chunks == -1:
             n_rtable_chunks = multiprocessing.cpu_count()
 
-        rtable_chunks = pd.np.array_split(rtable, n_rtable_chunks)
+        rtable_chunks = np.array_split(rtable, n_rtable_chunks)
 
         # Construct the DAG for probing
         probe_result = []
@@ -508,7 +509,7 @@ class DaskOverlapBlocker(Blocker):
 
 
         n_chunks = get_num_partitions(n_chunks, len(candset))
-        c_splits = pd.np.array_split(candset, n_chunks)
+        c_splits = np.array_split(candset, n_chunks)
         valid_splits = []
 
         # Create DAG

--- a/py_entitymatching/dask/dask_rule_based_blocker.py
+++ b/py_entitymatching/dask/dask_rule_based_blocker.py
@@ -2,6 +2,7 @@ import logging
 from collections import OrderedDict
 
 import pandas as pd
+import numpy as np
 import pyprind
 import six
 
@@ -484,7 +485,7 @@ class DaskRuleBasedBlocker(Blocker):
                                                         show_progress)
         else:
             # multiprocessing
-            c_splits = pd.np.array_split(c_df, n_chunks)
+            c_splits = np.array_split(c_df, n_chunks)
 
             valid_splits = []
 
@@ -546,8 +547,8 @@ class DaskRuleBasedBlocker(Blocker):
         else:
             # multiprocessing
             # m, n = self.get_split_params(n_procs, len(l_df), len(r_df))
-            l_splits = pd.np.array_split(l_df, n_ltable_chunks)
-            r_splits = pd.np.array_split(r_df, n_rtable_chunks)
+            l_splits = np.array_split(l_df, n_ltable_chunks)
+            r_splits = np.array_split(r_df, n_rtable_chunks)
 
             c_splits = []
             for i in range(len(l_splits)):

--- a/py_entitymatching/dask/daskmlmatcher.py
+++ b/py_entitymatching/dask/daskmlmatcher.py
@@ -4,8 +4,8 @@ all the ML-matchers.
 """
 import logging
 
-# import numpy as np
 import pandas as pd
+import numpy as np
 
 # import dask
 import dask
@@ -281,7 +281,7 @@ class DaskMLMatcher(Matcher):
 
             else:
                 predicted_results = []
-                splitted_tables = pd.np.array_split(table, n_chunks)
+                splitted_tables = np.array_split(table, n_chunks)
                 for i in range(len(splitted_tables)):
                     partial_result = delayed(self._predict)(table=splitted_tables[i],
                                                             exclude_attrs=exclude_attrs, target_attr=target_attr,
@@ -385,7 +385,7 @@ class DaskMLMatcher(Matcher):
             # Get the values from the DataFrame
             x = x.values
             # Remove the first column ('_id')
-            x = pd.np.delete(x, 0, 1)
+            x = np.delete(x, 0, 1)
         else:
             # Get the values from the DataFrame
             x = x.values
@@ -398,7 +398,7 @@ class DaskMLMatcher(Matcher):
                     'Removing this column for processing')
                 # Get the values from the DataFrame
                 y = y.values
-                y = pd.np.delete(y, 0, 1)
+                y = np.delete(y, 0, 1)
             else:
                 # Get the values from the DataFrame
                 y = y.values

--- a/py_entitymatching/debugmatcher/debug_decisiontree_matcher.py
+++ b/py_entitymatching/debugmatcher/debug_decisiontree_matcher.py
@@ -6,6 +6,7 @@ import logging
 import subprocess
 
 import pandas as pd
+import numpy as np
 import six
 from py_entitymatching.utils.validation_helper import validate_object_type
 from sklearn.tree import export_graphviz
@@ -136,8 +137,8 @@ def _get_code(tree, feature_names, target_names,
             target = value[node]
             winning_target_name = None
             winning_target_count = None
-            for i, v in zip(pd.np.nonzero(target)[1],
-                            target[pd.np.nonzero(target)]):
+            for i, v in zip(np.nonzero(target)[1],
+                            target[np.nonzero(target)]):
                 target_name = target_names[i]
                 target_count = int(v)
                 if winning_target_count == None:

--- a/py_entitymatching/debugmatcher/debug_gui_utils.py
+++ b/py_entitymatching/debugmatcher/debug_gui_utils.py
@@ -3,7 +3,7 @@ This module contains utility functions for debugging matchers.
 """
 import pandas as pd
 from collections import OrderedDict
-# import numpy as np
+import numpy as np
 
 import py_entitymatching.catalog.catalog_manager as cm
 
@@ -126,8 +126,8 @@ def _get_code_vis(tree, feature_names, target_names,
             target = value[node]
             winning_target_name = None
             winning_target_count = None
-            for i, v in zip(pd.np.nonzero(target)[1],
-                            target[pd.np.nonzero(target)]):
+            for i, v in zip(np.nonzero(target)[1],
+                            target[np.nonzero(target)]):
                 target_name = target_names[i]
                 target_count = int(v)
                 if winning_target_count == None:

--- a/py_entitymatching/feature/attributeutils.py
+++ b/py_entitymatching/feature/attributeutils.py
@@ -4,6 +4,7 @@ This module contains some utility functions for attributes in the DataFrame.
 import logging
 
 import pandas as pd
+import numpy as np
 import six
 
 from py_entitymatching.utils.validation_helper import validate_object_type
@@ -188,7 +189,7 @@ def _get_type(column):
         # the number of types is 1.
         returned_type = type_list[0]
         # Check if the type is boolean, if so return boolean
-        if returned_type == bool or returned_type == pd.np.bool_:
+        if returned_type == bool or returned_type == np.bool_:
             return 'boolean'
 
         # Check if the type is string, if so identify the subtype under it.
@@ -221,4 +222,4 @@ def _len_handle_nan(input_list):
     if isinstance(input_list, list):
         return len(input_list)
     else:
-        return pd.np.NaN
+        return np.NaN

--- a/py_entitymatching/feature/extractfeatures.py
+++ b/py_entitymatching/feature/extractfeatures.py
@@ -7,6 +7,7 @@ import multiprocessing
 import os
 
 import pandas as pd
+import numpy as np
 import pyprind
 import tempfile
 
@@ -154,7 +155,7 @@ def extract_feature_vecs(candset, attrs_before=None, feature_table=None,
 
     n_procs = get_num_procs(n_jobs, len(candset))
 
-    c_splits = pd.np.array_split(candset, n_procs)
+    c_splits = np.array_split(candset, n_procs)
 
     pickled_obj = cloudpickle.dumps(feature_table)
 

--- a/py_entitymatching/feature/simfunctions.py
+++ b/py_entitymatching/feature/simfunctions.py
@@ -4,6 +4,7 @@ This module contains similarity functions supported by py_entitymatching
 """
 
 import pandas as pd
+import numpy as np
 import six
 
 import py_stringmatching as sm
@@ -123,9 +124,9 @@ def affine(s1, s2):
         nan
     """
     if s1 is None or s2 is None:
-        return pd.np.NaN
+        return np.NaN
     if pd.isnull(s1) or pd.isnull(s2):
-        return pd.np.NaN
+        return np.NaN
 
     # Create the similarity measure object
     measure = sm.Affine()
@@ -172,9 +173,9 @@ def hamming_dist(s1, s2):
     """
 
     if s1 is None or s2 is None:
-        return pd.np.NaN
+        return np.NaN
     if pd.isnull(s1) or pd.isnull(s2):
-        return pd.np.NaN
+        return np.NaN
 
     # Create the similarity measure object
     measure = sm.HammingDistance()
@@ -210,9 +211,9 @@ def hamming_sim(s1, s2):
     """
 
     if s1 is None or s2 is None:
-        return pd.np.NaN
+        return np.NaN
     if pd.isnull(s1) or pd.isnull(s2):
-        return pd.np.NaN
+        return np.NaN
 
     # Create the similarity measure object
     measure = sm.HammingDistance()
@@ -247,9 +248,9 @@ def lev_dist(s1, s2):
     """
 
     if s1 is None or s2 is None:
-        return pd.np.NaN
+        return np.NaN
     if pd.isnull(s1) or pd.isnull(s2):
-        return pd.np.NaN
+        return np.NaN
 
     # Create the similarity measure object
     measure = sm.Levenshtein()
@@ -284,9 +285,9 @@ def lev_sim(s1, s2):
     """
 
     if s1 is None or s2 is None:
-        return pd.np.NaN
+        return np.NaN
     if pd.isnull(s1) or pd.isnull(s2):
-        return pd.np.NaN
+        return np.NaN
 
     # Create the similarity measure object
     measure = sm.Levenshtein()
@@ -320,9 +321,9 @@ def jaro(s1, s2):
     """
 
     if s1 is None or s2 is None:
-        return pd.np.NaN
+        return np.NaN
     if pd.isnull(s1) or pd.isnull(s2):
-        return pd.np.NaN
+        return np.NaN
 
     # Create the similarity measure object
     measure = sm.Jaro()
@@ -357,9 +358,9 @@ def jaro_winkler(s1, s2):
     """
 
     if s1 is None or s2 is None:
-        return pd.np.NaN
+        return np.NaN
     if pd.isnull(s1) or pd.isnull(s2):
-        return pd.np.NaN
+        return np.NaN
 
     # Create the similarity measure object
     measure = sm.JaroWinkler()
@@ -395,9 +396,9 @@ def needleman_wunsch(s1, s2):
     """
 
     if s1 is None or s2 is None:
-        return pd.np.NaN
+        return np.NaN
     if pd.isnull(s1) or pd.isnull(s2):
-        return pd.np.NaN
+        return np.NaN
 
     # Create the similarity measure object
     measure = sm.NeedlemanWunsch()
@@ -431,9 +432,9 @@ def smith_waterman(s1, s2):
     """
 
     if s1 is None or s2 is None:
-        return pd.np.NaN
+        return np.NaN
     if pd.isnull(s1) or pd.isnull(s2):
-        return pd.np.NaN
+        return np.NaN
 
     # Create the similarity measure object
     measure = sm.SmithWaterman()
@@ -468,15 +469,15 @@ def jaccard(arr1, arr2):
     """
 
     if arr1 is None or arr2 is None:
-        return pd.np.NaN
+        return np.NaN
     if not isinstance(arr1, list):
         arr1 = [arr1]
     if any(pd.isnull(arr1)):
-        return pd.np.NaN
+        return np.NaN
     if not isinstance(arr2, list):
         arr2 = [arr2]
     if any(pd.isnull(arr2)):
-        return pd.np.NaN
+        return np.NaN
     # Create jaccard measure object
     measure = sm.Jaccard()
     # Call a function to compute a similarity score
@@ -506,15 +507,15 @@ def cosine(arr1, arr2):
     """
 
     if arr1 is None or arr2 is None:
-        return pd.np.NaN
+        return np.NaN
     if not isinstance(arr1, list):
         arr1 = [arr1]
     if any(pd.isnull(arr1)):
-        return pd.np.NaN
+        return np.NaN
     if not isinstance(arr2, list):
         arr2 = [arr2]
     if any(pd.isnull(arr2)):
-        return pd.np.NaN
+        return np.NaN
     # Create cosine measure object
     measure = sm.Cosine()
     # Call the function to compute the cosine measure.
@@ -544,15 +545,15 @@ def overlap_coeff(arr1, arr2):
     """
 
     if arr1 is None or arr2 is None:
-        return pd.np.NaN
+        return np.NaN
     if not isinstance(arr1, list):
         arr1 = [arr1]
     if any(pd.isnull(arr1)):
-        return pd.np.NaN
+        return np.NaN
     if not isinstance(arr2, list):
         arr2 = [arr2]
     if any(pd.isnull(arr2)):
-        return pd.np.NaN
+        return np.NaN
     # Create overlap coefficient measure object
     measure = sm.OverlapCoefficient()
     # Call the function to return the overlap coefficient
@@ -581,15 +582,15 @@ def dice(arr1, arr2):
     """
 
     if arr1 is None or arr2 is None:
-        return pd.np.NaN
+        return np.NaN
     if not isinstance(arr1, list):
         arr1 = [arr1]
     if any(pd.isnull(arr1)):
-        return pd.np.NaN
+        return np.NaN
     if not isinstance(arr2, list):
         arr2 = [arr2]
     if any(pd.isnull(arr2)):
-        return pd.np.NaN
+        return np.NaN
 
     # Create Dice object
     measure = sm.Dice()
@@ -620,15 +621,15 @@ def monge_elkan(arr1, arr2):
     """
 
     if arr1 is None or arr2 is None:
-        return pd.np.NaN
+        return np.NaN
     if not isinstance(arr1, list):
         arr1 = [arr1]
     if any(pd.isnull(arr1)):
-        return pd.np.NaN
+        return np.NaN
     if not isinstance(arr2, list):
         arr2 = [arr2]
     if any(pd.isnull(arr2)):
-        return pd.np.NaN
+        return np.NaN
     # Create Monge-Elkan measure object
     measure = sm.MongeElkan()
     # Call the function to compute the Monge-Elkan measure
@@ -670,9 +671,9 @@ def exact_match(d1, d2):
         nan
     """
     if d1 is None or d2 is None:
-        return pd.np.NaN
+        return np.NaN
     if pd.isnull(d1) or pd.isnull(d2):
-        return pd.np.NaN
+        return np.NaN
     # Check if they match exactly
     if d1 == d2:
         return 1
@@ -705,14 +706,14 @@ def rel_diff(d1, d2):
     """
 
     if d1 is None or d2 is None:
-        return pd.np.NaN
+        return np.NaN
     if pd.isnull(d1) or pd.isnull(d2):
-        return pd.np.NaN
+        return np.NaN
     try:
         d1 = float(d1)
         d2 = float(d2)
     except ValueError:
-        return pd.np.NaN
+        return np.NaN
     if d1 == 0.0 and d2 == 0.0:
         return 0
     else:
@@ -748,14 +749,14 @@ def abs_norm(d1, d2):
     """
 
     if d1 is None or d2 is None:
-        return pd.np.NaN
+        return np.NaN
     if pd.isnull(d1) or pd.isnull(d2):
-        return pd.np.NaN
+        return np.NaN
     try:
         d1 = float(d1)
         d2 = float(d2)
     except ValueError:
-        return pd.np.NaN
+        return np.NaN
     if d1 == 0.0 and d2 == 0.0:
         return 0
     else:

--- a/py_entitymatching/feature/tokenizers.py
+++ b/py_entitymatching/feature/tokenizers.py
@@ -5,6 +5,7 @@ This module contains the tokenizer functions supported by py_entitymatching.
 import logging
 
 import pandas as pd
+import numpy as np
 import six
 
 import py_stringmatching as sm
@@ -208,7 +209,7 @@ def tok_qgram(input_string, q):
     """
 
     if pd.isnull(input_string):
-        return pd.np.NaN
+        return np.NaN
 
     input_string = gh.convert_to_str_unicode(input_string)
     measure = sm.QgramTokenizer(qval=q)
@@ -242,7 +243,7 @@ def tok_delim(input_string, d):
     """
 
     if pd.isnull(input_string):
-        return pd.np.NaN
+        return np.NaN
 
     input_string = gh.convert_to_str_unicode(input_string)
 
@@ -274,7 +275,7 @@ def tok_wspace(input_string):
 
     """
     if pd.isnull(input_string):
-        return pd.np.NaN
+        return np.NaN
 
     # input_string = remove_non_ascii(input_string)
     input_string = gh.convert_to_str_unicode(input_string)
@@ -306,7 +307,7 @@ def tok_alphabetic(input_string):
 
     """
     if pd.isnull(input_string):
-        return pd.np.NaN
+        return np.NaN
     measure = sm.AlphabeticTokenizer()
 
     input_string = gh.convert_to_str_unicode(input_string)
@@ -337,7 +338,7 @@ def tok_alphanumeric(input_string):
 
     """
     if pd.isnull(input_string):
-      return pd.np.NaN
+      return np.NaN
 
     input_string = gh.convert_to_str_unicode(input_string)
 

--- a/py_entitymatching/matcher/ensemblematcher.py
+++ b/py_entitymatching/matcher/ensemblematcher.py
@@ -2,9 +2,9 @@
 This module contains functions for ensembe matcher.
 Note: This is not going to be there in the first version of py_entitymatching.
 """
-# import numpy as np
 
 import pandas as pd
+import numpy as np
 import six
 
 from sklearn.base import BaseEstimator
@@ -40,7 +40,7 @@ class EnsembleSKLearn(BaseEstimator, ClassifierMixin, TransformerMixin):
 
     def _predict(self, X):
         """ Collect results from clf.predict calls. """
-        predictions =  pd.np.asarray([clf.predict(X) for clf in self.clfs_]).T
+        predictions =  np.asarray([clf.predict(X) for clf in self.clfs_]).T
         predicted_labels = self.combiner.combine(predictions)
         return predicted_labels
 

--- a/py_entitymatching/matcher/matcherutils.py
+++ b/py_entitymatching/matcher/matcherutils.py
@@ -7,6 +7,7 @@ import time
 from collections import OrderedDict
 
 import pandas as pd
+import numpy as np
 import sklearn.model_selection as ms
 from  sklearn.preprocessing import Imputer
 
@@ -95,7 +96,7 @@ def split_train_test(labeled_data, train_proportion=0.5,
     test_size = int(num_rows - train_size)
 
     # Use sk-learn to split the data
-    idx_values = pd.np.array(labeled_data.index.values)
+    idx_values = np.array(labeled_data.index.values)
     idx_train, idx_test = ms.train_test_split(idx_values, test_size=test_size,
                                               train_size=train_size,
                                               random_state=random_state)
@@ -220,7 +221,7 @@ def impute_table(table, exclude_attrs=None, missing_val='NaN',
 
     imp = Imputer(missing_values=missing_val, strategy=strategy, axis=axis)
     imp.fit(projected_table_values)
-    imp.statistics_[pd.np.isnan(imp.statistics_)] = val_all_nans
+    imp.statistics_[np.isnan(imp.statistics_)] = val_all_nans
     projected_table_values = imp.transform(projected_table_values)
     table_copy[feature_names] = projected_table_values
     # Update catalog

--- a/py_entitymatching/matcher/mlmatcher.py
+++ b/py_entitymatching/matcher/mlmatcher.py
@@ -4,8 +4,8 @@ all the ML-matchers.
 """
 import logging
 
-# import numpy as np
 import pandas as pd
+import numpy as np
 
 import py_entitymatching.catalog.catalog_manager as cm
 from py_entitymatching.matcher.matcher import Matcher
@@ -301,7 +301,7 @@ class MLMatcher(Matcher):
             # Get the values from the DataFrame
             x = x.values
             # Remove the first column ('_id')
-            x = pd.np.delete(x, 0, 1)
+            x = np.delete(x, 0, 1)
         else:
             # Get the values from the DataFrame
             x = x.values
@@ -314,7 +314,7 @@ class MLMatcher(Matcher):
                     'Removing this column for processing')
                 # Get the values from the DataFrame
                 y = y.values
-                y = pd.np.delete(y, 0, 1)
+                y = np.delete(y, 0, 1)
             else:
                 # Get the values from the DataFrame
                 y = y.values

--- a/py_entitymatching/matchercombiner/matchercombiner.py
+++ b/py_entitymatching/matchercombiner/matchercombiner.py
@@ -1,6 +1,6 @@
-# import numpy as np
 from math import ceil
 import pandas as pd
+import numpy as np
 
 class MajorityVote(object):
     """
@@ -43,8 +43,8 @@ class MajorityVote(object):
             >>> mv_combiner = MajorityVote()
             >>> L['consol_predictions'] = mv_combiner.combine(L[['dt_predictions', 'rf_predictions', 'nb_predictions']])
         """
-        combined_prediction = pd.np.apply_along_axis(lambda x: pd.np.argmax(
-            pd.np.bincount(x)), axis=1, arr=predictions)
+        combined_prediction = np.apply_along_axis(lambda x: np.argmax(
+            np.bincount(x)), axis=1, arr=predictions)
         return combined_prediction
 
 class WeightedVote(object):
@@ -102,15 +102,15 @@ class WeightedVote(object):
         num_matchers = predictions.shape[1]
         if self.weights is not None:
             assert num_matchers is len(num_matchers), 'Num matchers and weights do not match'
-            w = pd.np.asarray(self.weights)
+            w = np.asarray(self.weights)
         else:
-            w = pd.np.ones(num_matchers, )
+            w = np.ones(num_matchers, )
 
         if self.threshold is None:
             t = ceil((num_matchers+1.0)/2.0)
         else:
             t = self.threshold
 
-        combined_prediction = pd.np.apply_along_axis(lambda x: 1 if
-        pd.np.inner(x, w) >= t else 0, axis=1, arr=predictions)
+        combined_prediction = np.apply_along_axis(lambda x: 1 if
+        np.inner(x, w) >= t else 0, axis=1, arr=predictions)
         return combined_prediction

--- a/py_entitymatching/matcherselector/mlmatcherselection.py
+++ b/py_entitymatching/matcherselector/mlmatcherselection.py
@@ -5,6 +5,7 @@ import logging
 from collections import OrderedDict
 
 import pandas as pd
+import numpy as np
 from sklearn.model_selection import KFold, cross_val_score
 
 from py_entitymatching.utils.catalog_helper import check_attrs_present
@@ -125,15 +126,15 @@ def select_matcher(matchers, x=None, y=None, table=None, exclude_attrs=None,
             # Fill a dictionary based on the matcher and the scores.
             val_list = [matcher.get_name(), matcher, k]
             val_list.extend(scores)
-            val_list.append(pd.np.mean(scores))
+            val_list.append(np.mean(scores))
             d = OrderedDict(zip(header, val_list))
             dict_list.append(d)
             # Create a list of the mean scores for each matcher
-            mean_score_list.append(pd.np.mean(scores))
+            mean_score_list.append(np.mean(scores))
             # Select the matcher based on the mean score, but only for metric_to_select_matcher
-            if met == metric_to_select_matcher and pd.np.mean(scores) > max_score:
+            if met == metric_to_select_matcher and np.mean(scores) > max_score:
                 sel_matcher = m
-                max_score = pd.np.mean(scores)
+                max_score = np.mean(scores)
         # Create a DataFrame based on the list of dictionaries created
         stats = pd.DataFrame(dict_list)
         stats = stats[header]
@@ -194,7 +195,7 @@ def _get_xy_data_prj(x, y):
             'Input table contains "_id". Removing this column for processing')
         # Get the values  from the DataFrame
         x = x.values
-        x = pd.np.delete(x, 0, 1)
+        x = np.delete(x, 0, 1)
     else:
         x = x.values
 

--- a/py_entitymatching/sampler/down_sample.py
+++ b/py_entitymatching/sampler/down_sample.py
@@ -15,6 +15,7 @@ import string
 from collections import Counter
 
 import pandas as pd
+import numpy as np
 import pyprind
 from numpy.random import RandomState
 
@@ -351,7 +352,7 @@ def down_sample(table_a, table_b, size, y_param, show_progress=True,
                                            len(table_a), s_inv_index, show_progress,
                                            seed, rem_stop_words, rem_puncs)
     else:
-        sample_table_splits = pd.np.array_split(sample_table_b, n_jobs)
+        sample_table_splits = np.array_split(sample_table_b, n_jobs)
         results = Parallel(n_jobs=n_jobs)(
             delayed(_probe_index_split)(sample_table_splits[job_index], y_param,
                                        len(table_a), s_inv_index,

--- a/py_entitymatching/sampler/single_table.py
+++ b/py_entitymatching/sampler/single_table.py
@@ -5,6 +5,7 @@ This module contains sampling.rst related routines for a single table.
 import logging
 
 import pandas as pd
+import numpy as np
 import six
 
 import py_entitymatching.catalog.catalog_manager as cm
@@ -100,8 +101,8 @@ def sample_table(table, sample_size, replace=False, verbose=False):
                                       logger, verbose)
 
     # Get the sample set for the output table
-    sample_indices = pd.np.random.choice(len(table), sample_size,
-                                         replace=replace)
+    sample_indices = np.random.choice(len(table), sample_size,
+                                      replace=replace)
     # Sort the indices ordered by index value
     sample_indices = sorted(sample_indices)
     sampled_table = table.iloc[list(sample_indices)]

--- a/py_entitymatching/tests/_test_matcherselector_mlmatcherselection_xg.py
+++ b/py_entitymatching/tests/_test_matcherselector_mlmatcherselection_xg.py
@@ -2,6 +2,7 @@ import os
 from nose.tools import *
 import unittest
 import pandas as pd
+import numpy as np
 import six
 
 from py_entitymatching.utils.generic_helper import get_install_path, list_diff
@@ -59,7 +60,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
     # @nottest
@@ -98,7 +99,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
     # @nottest
@@ -137,7 +138,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
     # @nottest
@@ -176,7 +177,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
     # @nottest
@@ -215,7 +216,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
 
@@ -254,7 +255,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
     def test_select_matcher_valid_7(self):
@@ -295,7 +296,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
 

--- a/py_entitymatching/tests/test_catalog.py
+++ b/py_entitymatching/tests/test_catalog.py
@@ -2,6 +2,7 @@ import os
 from nose.tools import *
 import unittest
 import pandas as pd
+import numpy as np
 
 from py_entitymatching.utils.generic_helper import get_install_path
 import py_entitymatching.catalog.catalog_manager as cm
@@ -906,7 +907,7 @@ class CatalogManagerTestCases(unittest.TestCase):
         A = pd.read_csv(path_a)
         B = pd.read_csv(path_b)
         C = pd.read_csv(path_c)
-        C.loc[0, 'ltable_ID'] = pd.np.NaN
+        C.loc[0, 'ltable_ID'] = np.NaN
         status = ch.check_fk_constraint(C, 'ltable_ID', A, 'ID')
         self.assertEqual(status, False)
 

--- a/py_entitymatching/tests/test_debugblocker.py
+++ b/py_entitymatching/tests/test_debugblocker.py
@@ -1,8 +1,8 @@
 import os
 from nose.tools import *
 import unittest
-# import numpy as np
 import pandas as pd
+import numpy as np
 
 import py_entitymatching as em
 from py_entitymatching.utils.generic_helper import get_install_path
@@ -281,7 +281,7 @@ class DebugblockerTestCases(unittest.TestCase):
         self.assertEqual(B_wlist, expected_B_wlist)
 
     def test_get_feature_weight_3(self):
-        table = [[''], [pd.np.nan]]
+        table = [[''], [np.nan]]
         dataframe = pd.DataFrame(table)
         weight_list = db._get_feature_weight(dataframe)
         self.assertEqual(weight_list, [0.0])
@@ -383,7 +383,7 @@ class DebugblockerTestCases(unittest.TestCase):
         db._build_id_to_index_map(dataframe, key)
 
     def test_replace_nan_to_empty_1(self):
-        field = pd.np.nan
+        field = np.nan
         self.assertEqual(db._replace_nan_to_empty(field), '')
 
     def test_replace_nan_to_empty_2(self):
@@ -407,7 +407,7 @@ class DebugblockerTestCases(unittest.TestCase):
         self.assertEqual(actual_ret_column, expected_ret_column)
 
     def test_get_tokenized_column_2(self):
-        column = ['hello world', pd.np.nan, 'how are you',
+        column = ['hello world', np.nan, 'how are you',
                   '', 'this is a blocking debugger']
         actual_ret_column = db._get_tokenized_column(column)
         expected_ret_column = [['hello', 'world'], [''],
@@ -448,7 +448,7 @@ class DebugblockerTestCases(unittest.TestCase):
         self.assertEqual(actual_record_list, expected_record_list)
 
     def test_get_tokenized_table_3(self):
-        table = [[1, 'abc abc asdf', '123-3456-7890', pd.np.nan, '',
+        table = [[1, 'abc abc asdf', '123-3456-7890', np.nan, '',
                   '135 east  abc  st'],
                  [2, 'aaa bbb', '000-111-2222', '', '', '246  west abc st'],
                  [3, 'cc dd', '123-123-1231', 'cc', 'unknown', ' 246 west def st']]

--- a/py_entitymatching/tests/test_feature_simfunctions.py
+++ b/py_entitymatching/tests/test_feature_simfunctions.py
@@ -2,6 +2,7 @@ from functools import partial
 from nose.tools import *
 import unittest
 import pandas as pd
+import numpy as np
 import six
 
 import py_entitymatching.feature.simfunctions as sim
@@ -28,7 +29,7 @@ def test_invalid_input_cases():
 
                     'exact_match': sim.exact_match, 'rel_diff': sim.rel_diff,
                     'abs_norm': sim.abs_norm}
-    inputs = {'None': None, 'pd.np.NaN': pd.np.NaN}
+    inputs = {'None': None, 'np.NaN': np.NaN}
 
     for name, measure in six.iteritems(sim_measures):
         for label1, input1 in six.iteritems(inputs):

--- a/py_entitymatching/tests/test_feature_tokenizers.py
+++ b/py_entitymatching/tests/test_feature_tokenizers.py
@@ -2,6 +2,7 @@ from functools import partial
 from nose.tools import *
 import unittest
 import pandas as pd
+import numpy as np
 import six
 
 import py_entitymatching.feature.tokenizers as tok
@@ -52,11 +53,11 @@ class TokenizerTestCases(unittest.TestCase):
 
     def test_qgram_invalid(self):
         x = tok._make_tok_qgram(3)
-        self.assertEqual(pd.isnull(x(pd.np.NaN)), True)
+        self.assertEqual(pd.isnull(x(np.NaN)), True)
 
     def test_qgram_delim(self):
         x = tok._make_tok_delim(' ')
-        self.assertEqual(pd.isnull(x(pd.np.NaN)), True)
+        self.assertEqual(pd.isnull(x(np.NaN)), True)
 
     def test_tokqgram_valid(self):
         x = tok.tok_qgram('data science', 3)
@@ -68,9 +69,9 @@ class TokenizerTestCases(unittest.TestCase):
         self.assertEqual(len(x), 2)
 
     def test_tokqgram_invalid(self):
-        x = tok.tok_qgram(pd.np.NaN, 3)
+        x = tok.tok_qgram(np.NaN, 3)
         self.assertEqual(pd.isnull(x), True)
 
     def test_tokdelim_invalid(self):
-        x = tok.tok_delim(pd.np.NaN, ' ')
+        x = tok.tok_delim(np.NaN, ' ')
         self.assertEqual(pd.isnull(x), True)

--- a/py_entitymatching/tests/test_labeler.py
+++ b/py_entitymatching/tests/test_labeler.py
@@ -2,6 +2,7 @@ import os
 from nose.tools import *
 import unittest
 import pandas as pd
+import numpy as np
 import six
 
 from py_entitymatching.utils.generic_helper import get_install_path
@@ -43,7 +44,7 @@ class LabelTableTestCases(unittest.TestCase):
         label_values = [0]*num_zeros
         label_values.extend([1]*num_ones)
         D = self._test_label_table(C, col_name, label_values)
-        self.assertEqual(pd.np.sum(D[col_name]), num_ones)
+        self.assertEqual(np.sum(D[col_name]), num_ones)
         p1, p2 = cm.get_all_properties(C), cm.get_all_properties(D)
         self.assertEqual(p1, p2)
 
@@ -56,7 +57,7 @@ class LabelTableTestCases(unittest.TestCase):
         label_values = [0]*num_zeros
         label_values.extend([1]*num_ones)
         D = self._test_label_table(C, col_name, label_values)
-        self.assertEqual(pd.np.sum(D[col_name]), num_ones)
+        self.assertEqual(np.sum(D[col_name]), num_ones)
         p1, p2 = cm.get_all_properties(C), cm.get_all_properties(D)
         self.assertEqual(p1, p2)
 
@@ -88,7 +89,7 @@ class LabelTableTestCases(unittest.TestCase):
         label_values = [0]*num_zeros
         label_values.extend([1]*num_ones)
         D = self._test_label_table(C, col_name, label_values)
-        self.assertEqual(pd.np.sum(D[col_name]), num_ones)
+        self.assertEqual(np.sum(D[col_name]), num_ones)
         p1, p2 = cm.get_all_properties(C), cm.get_all_properties(D)
         self.assertEqual(p1, p2)
 
@@ -103,7 +104,7 @@ class LabelTableTestCases(unittest.TestCase):
     #     label_values = [0]*num_zeros
     #     label_values.extend([1]*num_ones)
     #     D = self._test_label_table(C, col_name, label_values)
-    #     # self.assertEqual(pd.np.sum(D[col_name]), num_ones)
+    #     # self.assertEqual(np.sum(D[col_name]), num_ones)
     #     # p1, p2 = cm.get_all_properties(C), cm.get_all_properties(D)
     #     # self.assertEqual(p1, p2)
 

--- a/py_entitymatching/tests/test_matcherselector_mlmatcherselection.py
+++ b/py_entitymatching/tests/test_matcherselector_mlmatcherselection.py
@@ -2,6 +2,7 @@ import os
 from nose.tools import *
 import unittest
 import pandas as pd
+import numpy as np
 import six
 
 from py_entitymatching.utils.generic_helper import get_install_path, list_diff
@@ -59,7 +60,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
     # @nottest
@@ -95,7 +96,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
     # @nottest
@@ -131,7 +132,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
     # @nottest
@@ -167,7 +168,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
     # @nottest
@@ -203,7 +204,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
     def test_select_matcher_valid_6(self):
@@ -238,7 +239,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
     def test_select_matcher_valid_7(self):
@@ -277,7 +278,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df.columns[len(result_df.columns) - 1])
         d = result_df.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
 
@@ -409,7 +410,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual('Mean score', result_df_p.columns[len(result_df_r.columns) - 1])
         d = result_df_p.set_index('Name')
         p_max = d.loc[result['selected_matcher'].name, 'Mean score']
-        a_max = pd.np.max(d['Mean score'])
+        a_max = np.max(d['Mean score'])
         self.assertEqual(p_max, a_max)
 
     def test_select_matcher_valid_cv_stats(self):
@@ -433,7 +434,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2, 3]])), True)
         d = result_df.set_index('Matcher')
         p_max = d.loc[result['selected_matcher'].name, 'Average precision']
-        a_max = pd.np.max(result_df_p['Mean score'])
+        a_max = np.max(result_df_p['Mean score'])
         self.assertEqual(p_max, a_max)
 
     def test_select_matcher_valid_cv_stats_2(self):
@@ -459,7 +460,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1, 2]])), True)
         d = result_df.set_index('Matcher')
         p_max = d.loc[result['selected_matcher'].name, 'Average recall']
-        a_max = pd.np.max(result_df_r['Mean score'])
+        a_max = np.max(result_df_r['Mean score'])
         self.assertEqual(p_max, a_max)
 
     def test_select_matcher_valid_cv_stats_3(self):
@@ -485,7 +486,7 @@ class MLMatcherSelectionTestCases(unittest.TestCase):
         self.assertEqual(set(header) == set(list(result_df.columns[[0, 1]])), True)
         d = result_df.set_index('Matcher')
         p_max = d.loc[result['selected_matcher'].name, 'Average recall']
-        a_max = pd.np.max(result_df_r['Mean score'])
+        a_max = np.max(result_df_r['Mean score'])
         self.assertEqual(p_max, a_max)
 
     @raises(KeyError)

--- a/py_entitymatching/tuner/tuner_down_sample.py
+++ b/py_entitymatching/tuner/tuner_down_sample.py
@@ -5,8 +5,8 @@ import math
 import multiprocessing
 import time
 
-import numpy as np
 import pandas as pd
+import numpy as np
 from dask import delayed
 from dask.diagnostics import ProgressBar
 
@@ -168,7 +168,7 @@ def execute(ltable, rtable, y_param, seed, should_rem_puncs,
                             rem_stop_words=should_rem_stop_words, rem_puncs = should_rem_puncs, n_ltable_chunks=n_ltable_chunks, n_rtable_chunks=n_rtable_chunks)
         t2 = time.time()
         times.append(t2-t1)
-    return pd.np.mean(times)
+    return np.mean(times)
 
 
 def should_swap(orig_order, swap_order,  y_param, seed, should_rem_puncs,
@@ -327,12 +327,12 @@ def sample_ltable(table, should_rem_puncs, should_rem_stop_words, n_bins,
     str_lens += [max(str_lens) + 1]
 
     # bin the string lengths
-    freq, edges = pd.np.histogram(str_lens, bins=n_bins)
+    freq, edges = np.histogram(str_lens, bins=n_bins)
 
     # compute the bin to which the string length map to
     bins = [[] for _ in range(n_bins)]
     keys = sorted(group_ids_len.keys())
-    positions = pd.np.digitize(keys, edges)
+    positions = np.digitize(keys, edges)
 
     # compute the number of entries in each bin
     for i in range(len(keys)):
@@ -352,7 +352,7 @@ def sample_ltable(table, should_rem_puncs, should_rem_stop_words, n_bins,
         num_tuples = num_tups_from_each_bin[i]
         if len_of_bins[i]:
             np.random.seed(seed)
-            tmp_samples = pd.np.random.choice(bins[i], num_tuples, replace=False)
+            tmp_samples = np.random.choice(bins[i], num_tuples, replace=False)
             if len(tmp_samples):
                 sampled.extend(tmp_samples)
 
@@ -414,7 +414,7 @@ def sample_rtable(table, should_rem_puncs, should_rem_stop_words, n_bins,
     counts = list(cnt_df['count'].values)
     counts += [max(counts) + 1]
 
-    freq, edges = pd.np.histogram(counts, bins=n_bins)
+    freq, edges = np.histogram(counts, bins=n_bins)
 
 
     # get the number of samples to be selected from each bin
@@ -423,7 +423,7 @@ def sample_rtable(table, should_rem_puncs, should_rem_stop_words, n_bins,
     # compute the bin to which the string length map to
     bins = [[] for _ in range(n_bins)]
     keys = sorted(cnt_ids.keys())
-    positions = pd.np.digitize(keys, edges)
+    positions = np.digitize(keys, edges)
 
     # compute the number of entries in each bin
     for i in range(len(keys)):
@@ -443,7 +443,7 @@ def sample_rtable(table, should_rem_puncs, should_rem_stop_words, n_bins,
         num_tuples = num_tups_from_each_bin[i]
         if len_of_bins[i]:
             np.random.seed(seed)
-            tmp_samples = pd.np.random.choice(bins[i], num_tuples, replace=False)
+            tmp_samples = np.random.choice(bins[i], num_tuples, replace=False)
             if len(tmp_samples):
                 sampled.extend(tmp_samples)
 
@@ -538,7 +538,7 @@ def _down_sample(ltable, rtable, y_param, show_progress=True, verbose=False,
     if n_ltable_chunks == -1:
         n_ltable_chunks = multiprocessing.cpu_count()
 
-    ltable_chunks = pd.np.array_split(proj_ltable, n_ltable_chunks)
+    ltable_chunks = np.array_split(proj_ltable, n_ltable_chunks)
     preprocessed_tokenized_tbl = []
     start_row_id = 0
     for i in range(len(ltable_chunks)):
@@ -570,7 +570,7 @@ def _down_sample(ltable, rtable, y_param, show_progress=True, verbose=False,
     if n_rtable_chunks == -1:
         n_rtable_chunks = multiprocessing.cpu_count()
 
-    rtable_chunks = pd.np.array_split(proj_rtable_sampled, n_rtable_chunks)
+    rtable_chunks = np.array_split(proj_rtable_sampled, n_rtable_chunks)
     probe_result = []
 
     for i in range(len(rtable_chunks)):

--- a/py_entitymatching/tuner/tuner_overlap_blocker.py
+++ b/py_entitymatching/tuner/tuner_overlap_blocker.py
@@ -172,7 +172,7 @@ def execute(ob_obj, ltable, rtable, l_overlap_attr, r_overlap_attr, rem_stop_wor
                                 n_rtable_chunks=n_rtable_chunks, show_progress=False)
         t2 = time.time()
         times.append(t2-t1)
-    return pd.np.mean(times)
+    return np.mean(times)
 
 
 
@@ -336,12 +336,12 @@ def sample_ltable(table, key, block_attr, should_rem_stop_words, ob_obj, n_bins,
     str_lens += [max(str_lens) + 1]
 
     # bin the string lengths
-    freq, edges = pd.np.histogram(str_lens, bins=n_bins)
+    freq, edges = np.histogram(str_lens, bins=n_bins)
 
     # compute the bin to which the string length map to
     bins = [[] for _ in range(n_bins)]
     keys = sorted(group_ids_len.keys())
-    positions = pd.np.digitize(keys, edges)
+    positions = np.digitize(keys, edges)
 
     # compute the number of entries in each bin
     for i in range(len(keys)):
@@ -361,7 +361,7 @@ def sample_ltable(table, key, block_attr, should_rem_stop_words, ob_obj, n_bins,
         num_tuples = num_tups_from_each_bin[i]
         if len_of_bins[i]:
             np.random.seed(seed)
-            tmp_samples = pd.np.random.choice(bins[i], num_tuples, replace=False)
+            tmp_samples = np.random.choice(bins[i], num_tuples, replace=False)
             if len(tmp_samples):
                 sampled.extend(tmp_samples)
 
@@ -409,7 +409,7 @@ def sample_rtable(table, key, overlap_attr, tokenizer,
     counts = list(cnt_df['count'].values)
     counts += [max(counts) + 1]
 
-    freq, edges = pd.np.histogram(counts, bins=n_bins)
+    freq, edges = np.histogram(counts, bins=n_bins)
 
     # get the number of samples to be selected from each bin
     num_samples = int(math.floor(sample_proportion * len(table)))
@@ -417,7 +417,7 @@ def sample_rtable(table, key, overlap_attr, tokenizer,
     # compute the bin to which the string length map to
     bins = [[] for _ in range(n_bins)]
     keys = sorted(cnt_ids.keys())
-    positions = pd.np.digitize(keys, edges)
+    positions = np.digitize(keys, edges)
 
     # compute the number of entries in each bin
     for i in range(len(keys)):
@@ -437,7 +437,7 @@ def sample_rtable(table, key, overlap_attr, tokenizer,
         num_tuples = num_tups_from_each_bin[i]
         if len_of_bins[i]:
             np.random.seed(seed)
-            tmp_samples = pd.np.random.choice(bins[i], num_tuples, replace=False)
+            tmp_samples = np.random.choice(bins[i], num_tuples, replace=False)
             if len(tmp_samples):
                 sampled.extend(tmp_samples)
 

--- a/py_entitymatching/utils/generic_helper.py
+++ b/py_entitymatching/utils/generic_helper.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 import pandas as pd
+import numpy as np
 import six
 
 import py_entitymatching.catalog.catalog_manager as cm
@@ -66,7 +67,7 @@ def rem_nan(table, attr):
         logger.error('Input attr not in the table columns')
         raise KeyError('Input attr. not in the table columns')
 
-    l = table.index.values[pd.np.where(table[attr].notnull())[0]]
+    l = table.index.values[np.where(table[attr].notnull())[0]]
     return table.loc[l]
 
 


### PR DESCRIPTION
This pull request replaces all the occurrences of 'pd.np' (numpy via pandas) with just 'np' (numpy directly); it also adds (or uncomments) 'import numpy where required.