### PR TITLE
Fix appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,7 @@ install:
   - activate py_entitymatching_test_env
 
   # Package dependencies
+  - python -m pip install --upgrade pip
   - pip install -r requirements.txt
   - if %PYTHON_VERSION%==3.5 (pip install PyQt5)
   - if %PYTHON_VERSION%==3.6 (pip install PyQt5)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,29 +4,13 @@ environment:
     CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
 
   matrix:
-    - PYTHON: "C:\\Python27_64"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-      CONDA_PY: "27"
-      APP_CONDA_PY: "2.7.18"
+    - PYTHON_VERSION: "2.7"
 
-    - PYTHON: "C:\\Python35_64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-      CONDA_PY: "35"
-      APP_CONDA_PY: "3.5.10"
+    - PYTHON_VERSION: "3.5"
       
-    - PYTHON: "C:\\Python36_64"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
-      CONDA_PY: "36"
-      APP_CONDA_PY: "3.6.12"
+    - PYTHON_VERSION: "3.6"
 
-    - PYTHON: "C:\\Python37_64"
-      PYTHON_VERSION: "3.7"
-      PYTHON_ARCH: "64"
-      CONDA_PY: "37"
-      APP_CONDA_PY: "3.7.9"
+    - PYTHON_VERSION: "3.7"
     
 platform:
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,39 +1,56 @@
 
 environment:
+  global:
+    CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
 
   matrix:
-
     - PYTHON: "C:\\Python27_64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
       CONDA_PY: "27"
+      CONDA_NPY: "16"
+      APP_CONDA_PY: "2.7.18"
 
     - PYTHON: "C:\\Python35_64"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
       CONDA_PY: "35"
+      CONDA_NPY: "19"
+      APP_CONDA_PY: "3.5.10"
       
     - PYTHON: "C:\\Python36_64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
       CONDA_PY: "36"
+      CONDA_NPY: "19"
+      APP_CONDA_PY: "3.6.12"
 
     - PYTHON: "C:\\Python37_64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       CONDA_PY: "37"
+      CONDA_NPY: "19"
+      APP_CONDA_PY: "3.7.9"
+    
+platform:
+  - x64
 
 install:
-  # this installs the appropriate Miniconda (Py2/Py3, 32/64 bit)
-  - powershell .\\continuous-integration\\appveyor\\install.ps1
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%PATH%
+  
+  # Config
+  - conda config --set always_yes yes
+  - conda update --quiet conda
+  - conda config --set restore_free_channel true
 
-  # Don't install from requirements-pip.txt, python-coveralls has broken dependencies on windows it seems.
-  - conda install --yes setuptools nose numpy pip coverage scipy pandas pyparsing six scikit-learn Cython cloudpickle joblib ipython
+  # Install dependencies
+  - conda install --yes setuptools nose pip coverage scipy pandas pyparsing six scikit-learn Cython cloudpickle joblib ipython
   - pip install -r requirements.txt
   - if %PYTHON_VERSION%==3.5 (pip install PyQt5)
   - if %PYTHON_VERSION%==3.6 (pip install PyQt5)
   - if %PYTHON_VERSION%==3.7 (pip install PyQt5)
+  
+  # Build extensions
   - python setup.py build_ext --inplace
 
 build: false
@@ -46,6 +63,6 @@ test_script:
 
 on_success:
   # Could run coveralls here but will leave that to travis tests
-  - echo Build succesful!
+  - echo Build successful!
   #- coverage report
   # coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,8 +41,7 @@ install:
 
   # Manage dependencies in a conda environment
   - conda create --yes -n py_entitymatching_test_env python=%PYTHON_VERSION% --no-default-packages
-  - conda init powershell
-  - conda activate py_entitymatching_test_env
+  - activate py_entitymatching_test_env
 
   # Package dependencies
   - pip install -r requirements.txt
@@ -59,7 +58,7 @@ install:
 build: false
 
 test_script:
-  - conda activate py_entitymatching_test_env
+  - activate py_entitymatching_test_env
   
   # Nosetests take care of unit tests
   - nosetests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,7 @@ install:
 
   # Package dependencies
   - python -m pip install --upgrade pip
+  - pip install "numpy<1.17"
   - pip install -r requirements.txt
   - if %PYTHON_VERSION%==3.5 (pip install PyQt5)
   - if %PYTHON_VERSION%==3.6 (pip install PyQt5)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,12 +36,12 @@ install:
   
   # Config
   - conda config --set always_yes yes
-  - conda update -n base conda
+  - conda update -n base -c defaults conda
   - conda config --set restore_free_channel true
 
   # Manage dependencies in a conda environment
   - conda create --yes -n py_entitymatching_test_env python=%PYTHON_VERSION% --no-default-packages
-  - conda activate py_entitymatching_test_env
+  - source activate py_entitymatching_test_env
 
   # Package dependencies
   - pip install -r requirements.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,8 @@ install:
 
   # Manage dependencies in a conda environment
   - conda create --yes -n py_entitymatching_test_env python=%PYTHON_VERSION% --no-default-packages
-  - source activate py_entitymatching_test_env
+  - conda init powershell
+  - conda activate py_entitymatching_test_env
 
   # Package dependencies
   - pip install -r requirements.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,9 @@ build: false
 test_script:
   - activate py_entitymatching_test_env
   
+  # Test dependencies
+  - pip install nose
+  
   # Nosetests take care of unit tests
   - nosetests
   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,28 +8,24 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
       CONDA_PY: "27"
-      CONDA_NPY: "16"
       APP_CONDA_PY: "2.7.18"
 
     - PYTHON: "C:\\Python35_64"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
       CONDA_PY: "35"
-      CONDA_NPY: "19"
       APP_CONDA_PY: "3.5.10"
       
     - PYTHON: "C:\\Python36_64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
       CONDA_PY: "36"
-      CONDA_NPY: "19"
       APP_CONDA_PY: "3.6.12"
 
     - PYTHON: "C:\\Python37_64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       CONDA_PY: "37"
-      CONDA_NPY: "19"
       APP_CONDA_PY: "3.7.9"
     
 platform:
@@ -43,12 +39,18 @@ install:
   - conda update --quiet conda
   - conda config --set restore_free_channel true
 
-  # Install dependencies
-  - conda install --yes setuptools nose pip coverage scipy pandas pyparsing six scikit-learn Cython cloudpickle joblib ipython
+  # Manage dependencies in a conda environment
+  - conda create --yes -n py_entitymatching_test_env python=%PYTHON_VERSION% --no-default-packages
+
+  # Package dependencies
+  - pip install --upgrade pip
   - pip install -r requirements.txt
   - if %PYTHON_VERSION%==3.5 (pip install PyQt5)
   - if %PYTHON_VERSION%==3.6 (pip install PyQt5)
   - if %PYTHON_VERSION%==3.7 (pip install PyQt5)
+  
+  # Build dependencies
+  - pip install Cython
   
   # Build extensions
   - python setup.py build_ext --inplace
@@ -56,9 +58,12 @@ install:
 build: false
 
 test_script:
+  - conda activate py_entitymatching_test_env
+  
   # Nosetests take care of unit tests
-  # Behave runs the example scripts and tries to verify if it produces the right output
   - nosetests
+  
+  # Behave runs the example scripts and tries to verify if it produces the right output
   #- behave --tags ~@skip # Everything without the tag @skip
 
 on_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,14 +36,14 @@ install:
   
   # Config
   - conda config --set always_yes yes
-  - conda update --quiet conda
+  - conda update -n base conda
   - conda config --set restore_free_channel true
 
   # Manage dependencies in a conda environment
   - conda create --yes -n py_entitymatching_test_env python=%PYTHON_VERSION% --no-default-packages
+  - conda activate py_entitymatching_test_env
 
   # Package dependencies
-  - pip install --upgrade pip
   - pip install -r requirements.txt
   - if %PYTHON_VERSION%==3.5 (pip install PyQt5)
   - if %PYTHON_VERSION%==3.6 (pip install PyQt5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib>=2.2.4
 PyPrind
 py-stringmatching>=0.2.1
 py-stringsimjoin>=0.3.0
-numpy==1.16.2
+numpy
 scikit-learn==0.20
 scipy==1.2.0
 cloudpickle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests
 ipython==5.6
 matplotlib>=2.2.4
-PyPrind
+PyPrind==2.9.8
 py-stringmatching>=0.2.1
 py-stringsimjoin>=0.3.0
 numpy


### PR DESCRIPTION
This PR addresses #143, restructuring appveyor.yml to use AppVeyor's preinstalled Miniconda. Includes pinning the lowest common denominator for numpy to support Python 2.