### PR TITLE
Allow different implementations of feature extraction.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,18 @@ matrix:
     python: 3.8
     env:
       - PYTHON_VERSION=3.8
-  - os: osx                                                                     
+  - os: osx
+    osx_image: xcode12                                                                     
     language: generic                                                           
     env:                                                                        
       - PYTHON_VERSION=3.6
   - os: osx
+    osx_image: xcode12
     language: generic
     env:
       - PYTHON_VERSION=3.7
   - os: osx
+    osx_image: xcode12
     language: generic
     env:
       - PYTHON_VERSION=3.8

--- a/py_entitymatching/tests/test_validation_helper.py
+++ b/py_entitymatching/tests/test_validation_helper.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+
+import unittest
+
+from nose.tools import *
+import pandas as pd
+
+from py_entitymatching.utils import validation_helper as vh
+
+
+class ValidationHelperTestCases(unittest.TestCase):
+    def test_validate_object_type_with_valid_type(self):
+        vh.validate_object_type('ABC', str)
+        vh.validate_object_type(pd.DataFrame(), pd.DataFrame)
+        vh.validate_object_type(list(), list),
+        vh.validate_object_type(True, bool),
+        vh.validate_object_type(123, int),
+        vh.validate_object_type(dict(), dict)
+        
+        # Currently, can validate unexpected types
+        class A(object): pass
+        a = A()
+        vh.validate_object_type(a, A)
+
+    def test_validate_object_type_with_invalid_type(self):
+        self.assertRaises(AssertionError, lambda: vh.validate_object_type('ABC', int))
+        self.assertRaises(AssertionError, lambda: vh.validate_object_type(123, str))
+        self.assertRaises(AssertionError, lambda: vh.validate_object_type(list(), dict))
+        self.assertRaises(AssertionError, lambda: vh.validate_object_type(dict(), list))
+
+    def test_validate_object_type_with_unexpected_type(self):
+        class B(object): pass
+        self.assertRaises(KeyError, lambda: vh.validate_object_type(123, B))
+
+    def test_validate_subclass_with_valid_class(self):
+        class C(object): pass
+        class D(C): pass
+        class E(D): pass
+        vh.validate_subclass(E, E)
+        vh.validate_subclass(E, D)
+        vh.validate_subclass(E, C)
+
+    def test_validate_subclass_with_invalid_class(self):
+        class F(object): pass
+        class G(object): pass
+        class H(G): pass
+        self.assertRaises(AssertionError, lambda: vh.validate_subclass(G, F))
+        self.assertRaises(AssertionError, lambda: vh.validate_subclass(H, F))

--- a/py_entitymatching/utils/validation_helper.py
+++ b/py_entitymatching/utils/validation_helper.py
@@ -9,7 +9,8 @@ def type_name(expected_type):
         list: 'list',
         bool: 'bool',
         int: 'int',
-        dict: 'dictionary'
+        dict: 'dictionary',
+        str: 'str',
     }
     return messages[expected_type]
 
@@ -17,4 +18,10 @@ def type_name(expected_type):
 def validate_object_type(input_object, expected_type, error_prefix='Input object'):
     if not isinstance(input_object, expected_type):
         error_message = '{0}: {1} \nis not of type {2}'.format(error_prefix, str(input_object), type_name(expected_type))
+        raise AssertionError(error_message)
+
+
+def validate_subclass(input_class, expected_class, error_prefix='Input class'):
+    if not issubclass(input_class, expected_class):
+        error_message = f'{error_prefix}: {str(input_class)}\nis is not a sublcass of {str(expected_class)}'
         raise AssertionError(error_message)


### PR DESCRIPTION
Currently, the function `py_entitymatching.feature.extractfeatures.extract_feature_vecs()` relies on a single implementation of feature extraction that splits the candidate set into chunks and extracts features from each chunk in parallel. This works well in many situations, though feature extraction can take hours with 4-8 cores on a candidate set with tens of millions of rows and tens of features.

To give users some flexibility and control over how features are extracted, this PR does the following:
  - Defines an interface for feature extraction
  - Factors out the existing implementation into a class that implements the interface
  - Provides an alternate implementation that computes features over distinct input values