### PR TITLE
Add CI for Python 3.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
     python: 3.8
     env:
       - PYTHON_VERSION=3.8
+  - os: linux
+    python: 3.9
+    env:
+      - PYTHON_VERSION=3.9
   - os: osx
     osx_image: xcode12                                                                     
     language: generic                                                           
@@ -27,6 +31,11 @@ matrix:
     language: generic
     env:
       - PYTHON_VERSION=3.8
+  - os: osx
+    osx_image: xcode12
+    language: generic
+    env:
+      - PYTHON_VERSION=3.9
 
 compiler:
     - gcc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ environment:
     - PYTHON_VERSION: "3.7"
     
     - PYTHON_VERSION: "3.8"
+    
+    - PYTHON_VERSION: "3.9"
 
 platform:
   - x64

--- a/docs/user_manual/installation.rst
+++ b/docs/user_manual/installation.rst
@@ -4,7 +4,7 @@ Installation
 
 Requirements
 ------------
-* Python 2.7, 3.5, 3.6, 3.7, or 3.8
+* Python 3.6, 3.7, 3.8, or 3.9
 
 Platforms
 ---------
@@ -22,7 +22,7 @@ Dependencies
 * cloudpickle (provides functions to serialize Python constructs)
 * pyprind (library to display progress indicators)
 * pyparsing (library to parse strings)
-* six (provides functions to write compatible code across Python 2 and 3)
+* six
 * xgboost (provides an implementation for xgboost classifier)
 * pandas-profiling (provides implementation for profiling pandas dataframe)
 * pandas-table (provides data exploration tool for pandas dataframe)
@@ -47,9 +47,7 @@ command::
 
 
 The above command will install py_entitymatching and all of its dependencies except
-XGBoost, pandastable, openrefine, and PyQt5. This is because pip can only install the
-dependency packages that are available in PyPI and PyQt5, XGBoost, pandastable are not
-in PyPI for Python 2.
+XGBoost, pandastable, openrefine, and PyQt5.
 
 
 * To install PyQt5, follow the instructions at `this page <http://pyqt.sourceforge.net/Docs/PyQt5/installation.html>`_.
@@ -81,8 +79,6 @@ For more information see this StackOverflow `link <http://stackoverflow.com/ques
 The above commands will install py_entitymatching and all of its
 dependencies, except PyQt5 and XGBoost.
 
-This is  because, similar to pip, setup.py can only install the dependency packages 
-that are available in PyPI and PyQt5, pandastable, XGBoost are not in PyPI for Python 2.
 
 * To install PyQt5, follow the instructions at `this page <http://pyqt.sourceforge.net/Docs/PyQt5/installation.html>`_.
 

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ if __name__ == "__main__":
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
+            'Programming Language :: Python :: 3.9',
             'Topic :: Scientific/Engineering',
             'Topic :: Utilities',
             'Topic :: Software Development :: Libraries',


### PR DESCRIPTION
This PR adds Python 3.9 to the set of Python versions that `py-entitymatching` is tested against, updating the documentation accordingly.