### PR TITLE
Update matcherutils.py - fix module 'pandas' has no attribute 'np'

### DIFF
--- a/py_entitymatching/matcher/matcherutils.py
+++ b/py_entitymatching/matcher/matcherutils.py
@@ -221,7 +221,7 @@ def impute_table(table, exclude_attrs=None, missing_val=np.nan,
 
     imp = SimpleImputer(missing_values=missing_val, strategy=strategy, fill_value=fill_value)
     imp.fit(projected_table_values)
-    imp.statistics_[pd.np.isnan(imp.statistics_)] = val_all_nans
+    imp.statistics_[np.isnan(imp.statistics_)] = val_all_nans
     projected_table_values = imp.transform(projected_table_values)
     table_copy[feature_names] = projected_table_values
     # Update catalog


### PR DESCRIPTION
# Error:
`module 'pandas' has no attribute 'np' `  in line `py_entitymatching/matcher/matcherutils.py", line 224, in impute_table
    imp.statistics_[pd.np.isnan(imp.statistics_)] = val_all_nans`

# Fixed:
Replace `pd.np.isnan` with `np.isnan`